### PR TITLE
Add parent pom.xml to project

### DIFF
--- a/jOOQ-codegen-maven-example/pom.xml
+++ b/jOOQ-codegen-maven-example/pom.xml
@@ -1,55 +1,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>oss-parent</artifactId>
-        <groupId>org.sonatype.oss</groupId>
-        <version>7</version>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
 
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.jooq</groupId>
+		<artifactId>jooq-parent</artifactId>
+		<version>2.4.0-SNAPSHOT</version>
+	</parent>
+	
     <groupId>org.jooq</groupId>
     <artifactId>jooq-codegen-maven-example</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
-
-    <name>jOOQ Codegen Maven</name>
-    <description>jOOQ effectively combines complex SQL, typesafety, source code generation, active records, stored procedures, advanced data types, and Java in a fluent, intuitive DSL.</description>
-    <url>http://www.jooq.org</url>
-
-
-    <licenses>
-        <license>
-            <name>Apache License, Version 2.0</name>
-            <url>http://www.jooq.org/inc/LICENSE.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <scm>
-        <developerConnection>scm:svn:https://jooq.svn.sourceforge.net/svnroot/jooq</developerConnection>
-        <url>https://jooq.svn.sourceforge.net/svnroot/jooq</url>
-        <connection>scm:svn:https://jooq.svn.sourceforge.net/svnroot/jooq</connection>
-    </scm>
-
-    <issueManagement>
-        <system>Trac</system>
-        <url>https://sourceforge.net/apps/trac/jooq/report/6</url>
-    </issueManagement>
-
-    <developers>
-        <developer>
-            <name>Lukas Eder</name>
-            <email>lukas.eder@gmail.com</email>
-        </developer>
-        <developer>
-            <name>Sander Plas</name>
-            <email>sander.plas@gmail.com</email>
-        </developer>
-        <developer>
-            <name>Sergey Epik</name>
-            <email>sergey.epik@gmail.com</email>
-        </developer>
-    </developers>
+    <name>jOOQ Codegen Maven (Example)</name>
 
     <dependencies>
         <dependency>
@@ -92,9 +54,6 @@
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
-            <type>jar</type>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -146,16 +105,12 @@
     </properties>
 
     <build>
-        <defaultGoal>deploy</defaultGoal>
-        <finalName>${project.artifactId}-${project.version}</finalName>
-
         <plugins>
 
             <!-- The jOOQ code generator plugin for Postgres / Sybase ASE / MySQL -->
             <plugin>
                 <groupId>org.jooq</groupId>
                 <artifactId>jooq-codegen-maven</artifactId>
-                <version>2.4.0-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>exec0</id>
@@ -387,83 +342,6 @@
                     </dependency>
                 </dependencies>
             </plugin>
-
-            <!-- Plugins used for Maven Central -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <fork>true</fork>
-                    <maxmem>512m</maxmem>
-                    <meminitial>256m</meminitial>
-                    <encoding>UTF-8</encoding>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                    <debug>true</debug>
-                    <debuglevel>lines,vars,source</debuglevel>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <inherited>true</inherited>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-
-                <configuration>
-                    <excludeResources>true</excludeResources>
-                    <useDefaultExcludes>true</useDefaultExcludes>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <inherited>true</inherited>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.7</version>
-                <executions>
-                    <execution>
-                        <id>bundle-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <maxmemory>512</maxmemory>
-                    <encoding>UTF-8</encoding>
-                    <show>protected</show>
-                    <notree>true</notree>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>2.5</version>
-                <configuration>
-                    <encoding>UTF-8</encoding>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-eclipse-plugin</artifactId>
-                <version>2.8</version>
-                <configuration>
-                    <downloadSources>true</downloadSources>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 
@@ -475,7 +353,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/jOOQ-codegen-maven/pom.xml
+++ b/jOOQ-codegen-maven/pom.xml
@@ -1,134 +1,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>oss-parent</artifactId>
-        <groupId>org.sonatype.oss</groupId>
-        <version>7</version>
-    </parent>
+
     <modelVersion>4.0.0</modelVersion>
 
+	<parent>
+		<groupId>org.jooq</groupId>
+		<artifactId>jooq-parent</artifactId>
+		<version>2.4.0-SNAPSHOT</version>
+	</parent>
+	
     <groupId>org.jooq</groupId>
     <artifactId>jooq-codegen-maven</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
-    <packaging>maven-plugin</packaging>
-
     <name>jOOQ Codegen Maven</name>
-    <description>jOOQ effectively combines complex SQL, typesafety, source code generation, active records, stored procedures, advanced data types, and Java in a fluent, intuitive DSL.</description>
-    <url>http://www.jooq.org</url>
-
-
-    <licenses>
-        <license>
-            <name>Apache License, Version 2.0</name>
-            <url>http://www.jooq.org/inc/LICENSE.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <scm>
-        <developerConnection>scm:svn:https://jooq.svn.sourceforge.net/svnroot/jooq</developerConnection>
-        <url>https://jooq.svn.sourceforge.net/svnroot/jooq</url>
-        <connection>scm:svn:https://jooq.svn.sourceforge.net/svnroot/jooq</connection>
-    </scm>
-
-    <issueManagement>
-        <system>Trac</system>
-        <url>https://sourceforge.net/apps/trac/jooq/report/6</url>
-    </issueManagement>
-
-    <developers>
-        <developer>
-            <name>Lukas Eder</name>
-            <email>lukas.eder@gmail.com</email>
-        </developer>
-        <developer>
-            <name>Sander Plas</name>
-            <email>sander.plas@gmail.com</email>
-        </developer>
-    </developers>
-
-    <build>
-        <defaultGoal>deploy</defaultGoal>
-        <finalName>${project.artifactId}-${project.version}</finalName>
-
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <fork>true</fork>
-                    <maxmem>512m</maxmem>
-                    <meminitial>256m</meminitial>
-                    <encoding>UTF-8</encoding>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                    <debug>true</debug>
-                    <debuglevel>lines,vars,source</debuglevel>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <inherited>true</inherited>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-
-                <configuration>
-                    <excludeResources>true</excludeResources>
-                    <useDefaultExcludes>true</useDefaultExcludes>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <inherited>true</inherited>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.7</version>
-                <executions>
-                    <execution>
-                        <id>bundle-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <maxmemory>512</maxmemory>
-                    <encoding>UTF-8</encoding>
-                    <show>protected</show>
-                    <notree>true</notree>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>2.5</version>
-                <configuration>
-                    <encoding>UTF-8</encoding>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-eclipse-plugin</artifactId>
-                <version>2.8</version>
-                <configuration>
-                    <downloadSources>true</downloadSources>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>
@@ -138,7 +21,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/jOOQ-codegen/pom.xml
+++ b/jOOQ-codegen/pom.xml
@@ -1,119 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <parent>
-        <artifactId>oss-parent</artifactId>
-        <groupId>org.sonatype.oss</groupId>
-        <version>7</version>
-    </parent>
+
     <modelVersion>4.0.0</modelVersion>
 
+	<parent>
+		<groupId>org.jooq</groupId>
+		<artifactId>jooq-parent</artifactId>
+		<version>2.4.0-SNAPSHOT</version>
+	</parent>
+	
     <groupId>org.jooq</groupId>
     <artifactId>jooq-codegen</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
-
     <name>jOOQ Codegen</name>
-    <description>jOOQ effectively combines complex SQL, typesafety, source code generation, active records, stored procedures, advanced data types, and Java in a fluent, intuitive DSL.</description>
-    <url>http://www.jooq.org</url>
-
-
-    <licenses>
-        <license>
-            <name>Apache License, Version 2.0</name>
-            <url>http://www.jooq.org/inc/LICENSE.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <scm>
-        <developerConnection>scm:svn:https://jooq.svn.sourceforge.net/svnroot/jooq</developerConnection>
-        <url>https://jooq.svn.sourceforge.net/svnroot/jooq</url>
-        <connection>scm:svn:https://jooq.svn.sourceforge.net/svnroot/jooq</connection>
-    </scm>
-
-    <build>
-        <defaultGoal>deploy</defaultGoal>
-        <finalName>${project.artifactId}-${project.version}</finalName>
-
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <fork>true</fork>
-                    <maxmem>512m</maxmem>
-                    <meminitial>256m</meminitial>
-                    <encoding>UTF-8</encoding>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                    <debug>true</debug>
-                    <debuglevel>lines,vars,source</debuglevel>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <inherited>true</inherited>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-
-                <configuration>
-                    <excludeResources>true</excludeResources>
-                    <useDefaultExcludes>true</useDefaultExcludes>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <inherited>true</inherited>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.7</version>
-                <executions>
-                    <execution>
-                        <id>bundle-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <maxmemory>512</maxmemory>
-                    <encoding>UTF-8</encoding>
-                    <show>protected</show>
-                    <notree>true</notree>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>2.5</version>
-                <configuration>
-                    <encoding>UTF-8</encoding>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-eclipse-plugin</artifactId>
-                <version>2.8</version>
-                <configuration>
-                    <downloadSources>true</downloadSources>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>
@@ -123,7 +22,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -139,36 +37,14 @@
         </profile>
     </profiles>
 
-    <issueManagement>
-        <system>Trac</system>
-        <url>https://sourceforge.net/apps/trac/jooq/report/6</url>
-    </issueManagement>
-
-    <developers>
-        <developer>
-            <name>Lukas Eder</name>
-            <email>lukas.eder@gmail.com</email>
-        </developer>
-        <developer>
-            <name>Espen Stromsnes</name>
-            <email>estromsnes@gmail.com</email>
-        </developer>
-    </developers>
-
     <dependencies>
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
-            <type>jar</type>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq-meta</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
-            <type>jar</type>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.ant</groupId>

--- a/jOOQ-console/pom.xml
+++ b/jOOQ-console/pom.xml
@@ -1,118 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <parent>
-        <artifactId>oss-parent</artifactId>
-        <groupId>org.sonatype.oss</groupId>
-        <version>7</version>
-    </parent>
+
     <modelVersion>4.0.0</modelVersion>
 
+	<parent>
+		<groupId>org.jooq</groupId>
+		<artifactId>jooq-parent</artifactId>
+		<version>2.4.0-SNAPSHOT</version>
+	</parent>
+	
     <groupId>org.jooq</groupId>
     <artifactId>jooq-console</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
-
-    <name>jOOQ</name>
-    <description>jOOQ effectively combines complex SQL, typesafety, source code generation, active records, stored procedures, advanced data types, and Java in a fluent, intuitive DSL.</description>
-    <url>http://www.jooq.org</url>
-
-
-    <licenses>
-        <license>
-            <name>Apache License, Version 2.0</name>
-            <url>http://www.jooq.org/inc/LICENSE.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <scm>
-        <developerConnection>scm:svn:https://jooq.svn.sourceforge.net/svnroot/jooq</developerConnection>
-        <url>https://jooq.svn.sourceforge.net/svnroot/jooq</url>
-        <connection>scm:svn:https://jooq.svn.sourceforge.net/svnroot/jooq</connection>
-    </scm>
+    <name>jOOQ Console</name>
 
     <build>
-        <defaultGoal>deploy</defaultGoal>
-        <finalName>${project.artifactId}-${project.version}</finalName>
-
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <fork>true</fork>
-                    <maxmem>512m</maxmem>
-                    <meminitial>256m</meminitial>
-                    <encoding>UTF-8</encoding>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                    <debug>true</debug>
-                    <debuglevel>lines,vars,source</debuglevel>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <inherited>true</inherited>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-
-                <configuration>
-                    <excludeResources>true</excludeResources>
-                    <useDefaultExcludes>true</useDefaultExcludes>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <inherited>true</inherited>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.7</version>
-                <executions>
-                    <execution>
-                        <id>bundle-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <maxmemory>512</maxmemory>
-                    <encoding>UTF-8</encoding>
-                    <show>protected</show>
-                    <notree>true</notree>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>2.5</version>
-                <configuration>
-                    <encoding>UTF-8</encoding>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-eclipse-plugin</artifactId>
-                <version>2.8</version>
-                <configuration>
-                    <downloadSources>true</downloadSources>
-                </configuration>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
@@ -169,7 +72,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -184,21 +86,6 @@
             </build>
         </profile>
     </profiles>
-
-    <issueManagement>
-        <system>Trac</system>
-        <url>https://sourceforge.net/apps/trac/jooq/report/6</url>
-    </issueManagement>
-    <developers>
-        <developer>
-            <name>Lukas Eder</name>
-            <email>lukas.eder@gmail.com</email>
-        </developer>
-        <developer>
-            <name>Christopher Deckers</name>
-            <email>chrriis@gmail.com</email>
-        </developer>
-    </developers>
 
     <dependencies>
         <dependency>

--- a/jOOQ-meta/pom.xml
+++ b/jOOQ-meta/pom.xml
@@ -1,44 +1,108 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>oss-parent</artifactId>
-        <groupId>org.sonatype.oss</groupId>
-        <version>7</version>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.jooq</groupId>
+		<artifactId>jooq-parent</artifactId>
+		<version>2.4.0-SNAPSHOT</version>
+	</parent>
 
     <groupId>org.jooq</groupId>
     <artifactId>jooq-meta</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
-
     <name>jOOQ Meta</name>
-    <description>jOOQ effectively combines complex SQL, typesafety, source code generation, active records, stored procedures, advanced data types, and Java in a fluent, intuitive DSL.</description>
-    <url>http://www.jooq.org</url>
-
-
-    <licenses>
-        <license>
-            <name>Apache License, Version 2.0</name>
-            <url>http://www.jooq.org/inc/LICENSE.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <scm>
-        <connection>scm:svn:https://jooq.svn.sourceforge.net/svnroot/jooq</connection>
-        <developerConnection>scm:svn:https://jooq.svn.sourceforge.net/svnroot/jooq</developerConnection>
-        <url>https://jooq.svn.sourceforge.net/svnroot/jooq</url>
-    </scm>
 
     <build>
-        <defaultGoal>deploy</defaultGoal>
-        <finalName>${project.artifactId}-${project.version}</finalName>
-
         <plugins>
+            <!-- XJC-generate JAXB artefacts. Contribution is the courtesy of Sergey Epik -->
+            <plugin>
+                <groupId>org.jvnet.jaxb2.maven2</groupId>
+                <artifactId>maven-jaxb2-plugin</artifactId>
+                <version>0.8.1</version>
+                <executions>
+                    <execution>
+                    	<id>information_schema</id>
+                    	<goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+		                    <extension>true</extension>
+		                    <strict>false</strict>
+		                    <schemaDirectory>src/main/resources/xsd</schemaDirectory>
+		                    <schemaIncludes>
+		                        <include>information-schema-2.4.0.xsd</include>
+		                    </schemaIncludes>
+		                    <generatePackage>org.jooq.util.information_schema</generatePackage>
+		                    <args>
+		                        <arg>-Xxew</arg>
+		                        <arg>-Xxew:instantiate lazy</arg>
+		                        <arg>-Xxew:delete</arg>
+		                        <arg>-Xfluent-api</arg>
+		                        <arg>-Xdefault-value</arg>
+		                    </args>
+		                    <plugins>
+		                        <plugin>
+		                            <groupId>com.github.jaxb-xew-plugin</groupId>
+		                            <artifactId>jaxb-xew-plugin</artifactId>
+		                            <version>1.0</version>
+		                       </plugin>
+		                        <plugin>
+		                            <groupId>org.jvnet.jaxb2_commons</groupId>
+		                            <artifactId>jaxb2-fluent-api</artifactId>
+		                            <version>3.0</version>
+		                        </plugin>
+		                        <plugin>
+		                            <groupId>org.jvnet.jaxb2_commons</groupId>
+		                            <artifactId>jaxb2-default-value</artifactId>
+		                            <version>1.1</version>
+		                        </plugin>
+		                    </plugins>
+		                </configuration>
+                    </execution>
 
-            <!-- XJC-generate JAXB artefacts. Contribution is the courtesy
-                 of Sergey Epik -->
+                    <execution>
+                    	<id>configuration</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+	                        <forceRegenerate>true</forceRegenerate>
+		                    <extension>true</extension>
+		                    <strict>false</strict>
+		                    <schemaDirectory>src/main/resources/xsd</schemaDirectory>
+		                    <schemaIncludes>
+		                        <include>jooq-codegen-2.4.0.xsd</include>
+		                    </schemaIncludes>
+		                    <generatePackage>org.jooq.util.jaxb</generatePackage>
+		                    <args>
+		                        <arg>-Xxew</arg>
+		                        <arg>-Xxew:instantiate lazy</arg>
+		                        <arg>-Xxew:delete</arg>
+		                        <arg>-Xfluent-api</arg>
+		                        <arg>-Xdefault-value</arg>
+		                    </args>
+		                    <plugins>
+		                        <plugin>
+		                            <groupId>com.github.jaxb-xew-plugin</groupId>
+		                            <artifactId>jaxb-xew-plugin</artifactId>
+		                            <version>1.0</version>
+		                       </plugin>
+		                        <plugin>
+		                            <groupId>org.jvnet.jaxb2_commons</groupId>
+		                            <artifactId>jaxb2-fluent-api</artifactId>
+		                            <version>3.0</version>
+		                        </plugin>
+		                        <plugin>
+		                            <groupId>org.jvnet.jaxb2_commons</groupId>
+		                            <artifactId>jaxb2-default-value</artifactId>
+		                            <version>1.1</version>
+		                        </plugin>
+		                    </plugins>
+		                </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.jvnet.jaxb2.maven2</groupId>
                 <artifactId>maven-jaxb2-plugin</artifactId>
@@ -126,81 +190,6 @@
                 </executions>
             </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <fork>true</fork>
-                    <maxmem>512m</maxmem>
-                    <meminitial>256m</meminitial>
-                    <encoding>UTF-8</encoding>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                    <debug>true</debug>
-                    <debuglevel>lines,vars,source</debuglevel>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <inherited>true</inherited>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-
-                <configuration>
-                    <excludeResources>true</excludeResources>
-                    <useDefaultExcludes>true</useDefaultExcludes>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <inherited>true</inherited>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.7</version>
-                <executions>
-                    <execution>
-                        <id>bundle-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <maxmemory>512</maxmemory>
-                    <encoding>UTF-8</encoding>
-                    <show>protected</show>
-                    <notree>true</notree>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>2.5</version>
-                <configuration>
-                    <encoding>UTF-8</encoding>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-eclipse-plugin</artifactId>
-                <version>2.8</version>
-                <configuration>
-                    <downloadSources>true</downloadSources>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 
@@ -212,7 +201,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -228,29 +216,10 @@
         </profile>
     </profiles>
 
-    <issueManagement>
-        <system>Trac</system>
-        <url>https://sourceforge.net/apps/trac/jooq/report/6</url>
-    </issueManagement>
-
-    <developers>
-        <developer>
-            <name>Lukas Eder</name>
-            <email>lukas.eder@gmail.com</email>
-        </developer>
-        <developer>
-            <name>Espen Stromsnes</name>
-            <email>estromsnes@gmail.com</email>
-        </developer>
-    </developers>
-
     <dependencies>
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
-            <type>jar</type>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 </project>

--- a/jOOQ/pom.xml
+++ b/jOOQ/pom.xml
@@ -1,43 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <parent>
-        <artifactId>oss-parent</artifactId>
-        <groupId>org.sonatype.oss</groupId>
-        <version>7</version>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
 
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.jooq</groupId>
+		<artifactId>jooq-parent</artifactId>
+		<version>2.4.0-SNAPSHOT</version>
+	</parent>
+	
     <groupId>org.jooq</groupId>
     <artifactId>jooq</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
-
     <name>jOOQ</name>
-    <description>jOOQ effectively combines complex SQL, typesafety, source code generation, active records, stored procedures, advanced data types, and Java in a fluent, intuitive DSL.</description>
-    <url>http://www.jooq.org</url>
-
-
-    <licenses>
-        <license>
-            <name>Apache License, Version 2.0</name>
-            <url>http://www.jooq.org/inc/LICENSE.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <scm>
-        <developerConnection>scm:svn:https://jooq.svn.sourceforge.net/svnroot/jooq</developerConnection>
-        <url>https://jooq.svn.sourceforge.net/svnroot/jooq</url>
-        <connection>scm:svn:https://jooq.svn.sourceforge.net/svnroot/jooq</connection>
-    </scm>
 
     <build>
-        <defaultGoal>deploy</defaultGoal>
-        <finalName>${project.artifactId}-${project.version}</finalName>
-
         <plugins>
-
             <!-- XJC-generate JAXB artefacts. Contribution is the courtesy
                  of Sergey Epik -->
             <plugin>
@@ -87,82 +65,6 @@
                             <version>1.1</version>
                         </plugin>
                     </plugins>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <fork>true</fork>
-                    <maxmem>512m</maxmem>
-                    <meminitial>256m</meminitial>
-                    <encoding>UTF-8</encoding>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                    <debug>true</debug>
-                    <debuglevel>lines,vars,source</debuglevel>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <inherited>true</inherited>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-
-                <configuration>
-                    <excludeResources>true</excludeResources>
-                    <useDefaultExcludes>true</useDefaultExcludes>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <inherited>true</inherited>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.7</version>
-                <executions>
-                    <execution>
-                        <id>bundle-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <maxmemory>512</maxmemory>
-                    <encoding>UTF-8</encoding>
-                    <show>protected</show>
-                    <notree>true</notree>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>2.5</version>
-                <configuration>
-                    <encoding>UTF-8</encoding>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-eclipse-plugin</artifactId>
-                <version>2.8</version>
-                <configuration>
-                    <downloadSources>true</downloadSources>
                 </configuration>
             </plugin>
 
@@ -218,7 +120,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -233,21 +134,6 @@
             </build>
         </profile>
     </profiles>
-
-    <issueManagement>
-        <system>Trac</system>
-        <url>https://sourceforge.net/apps/trac/jooq/report/6</url>
-    </issueManagement>
-    <developers>
-        <developer>
-            <name>Lukas Eder</name>
-            <email>lukas.eder@gmail.com</email>
-        </developer>
-        <developer>
-            <name>Espen Stromsnes</name>
-            <email>estromsnes@gmail.com</email>
-        </developer>
-    </developers>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<artifactId>oss-parent</artifactId>
+		<groupId>org.sonatype.oss</groupId>
+		<version>7</version>
+	</parent>
+
+	<groupId>org.jooq</groupId>
+	<artifactId>jooq-parent</artifactId>
+	<version>2.4.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+	<name>jOOQ Parent</name>
+
+	<description>
+		jOOQ effectively combines complex SQL, typesafety, source code generation, active records,
+		stored procedures, advanced data types, and Java in a fluent, intuitive DSL.
+	</description>
+
+	<url>http://www.jooq.org</url>
+
+	<licenses>
+		<license>
+			<name>Apache License, Version 2.0</name>
+			<url>http://www.jooq.org/inc/LICENSE.txt</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
+	<scm>
+		<developerConnection>scm:svn:https://jooq.svn.sourceforge.net/svnroot/jooq</developerConnection>
+		<url>https://jooq.svn.sourceforge.net/svnroot/jooq</url>
+		<connection>scm:svn:https://jooq.svn.sourceforge.net/svnroot/jooq</connection>
+	</scm>
+
+	<issueManagement>
+		<system>Trac</system>
+		<url>https://sourceforge.net/apps/trac/jooq/report/6</url>
+	</issueManagement>
+
+	<developers>
+		<developer>
+			<name>Lukas Eder</name>
+			<email>lukas.eder@gmail.com</email>
+		</developer>
+		<developer>
+			<name>Espen Stromsnes</name>
+			<email>estromsnes@gmail.com</email>
+		</developer>
+	</developers>
+
+	<modules>
+		<module>jOOQ</module>
+		<module>jOOQ-codegen</module>
+		<module>jOOQ-codegen-maven</module>
+		<!--<module>jOOQ-codegen-maven-example</module>-->
+		<module>jOOQ-console</module>
+		<module>jOOQ-meta</module>
+	</modules>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.jooq</groupId>
+				<artifactId>jooq</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jooq</groupId>
+				<artifactId>jooq-codegen</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jooq</groupId>
+				<artifactId>jooq-codegen-maven</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jooq</groupId>
+				<artifactId>jooq-codegen-maven-example</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jooq</groupId>
+				<artifactId>jooq-console</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jooq</groupId>
+				<artifactId>jooq-meta</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<build>
+		<defaultGoal>deploy</defaultGoal>
+		<finalName>${project.artifactId}-${project.version}</finalName>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-gpg-plugin</artifactId>
+				<version>1.1</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.3.2</version>
+				<configuration>
+					<fork>true</fork>
+					<maxmem>512m</maxmem>
+					<meminitial>256m</meminitial>
+					<encoding>UTF-8</encoding>
+					<source>1.6</source>
+					<target>1.6</target>
+					<debug>true</debug>
+					<debuglevel>lines,vars,source</debuglevel>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<inherited>true</inherited>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>2.1.2</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<excludeResources>true</excludeResources>
+					<useDefaultExcludes>true</useDefaultExcludes>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>2.5</version>
+				<configuration>
+					<encoding>UTF-8</encoding>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-eclipse-plugin</artifactId>
+				<version>2.8</version>
+				<configuration>
+					<downloadSources>true</downloadSources>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<profiles>
+		<profile>
+			<id>javadoc</id>
+			<build>
+				<plugins>
+					<plugin>
+						<inherited>true</inherited>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<version>2.7</version>
+						<executions>
+							<execution>
+								<id>bundle-sources</id>
+								<phase>package</phase>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<maxmemory>512</maxmemory>
+							<encoding>UTF-8</encoding>
+							<show>protected</show>
+							<notree>true</notree>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
+</project>


### PR DESCRIPTION
I did this:
- add a parent pom.xml to the project (residing in the root folder)
- make javadoc documentation optional since it takes quite long (profile: javadoc)
- moved redundant entries from modules to parent pom.xml

this are the benefits:
- open parent pom.xml in your IDE (m2eclipse in Eclipse, IDEA, etc.) and have the full project loaded automatically including all inter-dependencies between projects
- build full project with e.g. 'mvn install'
- have less xml bloat
- project is easier to maintain (central point for managing stuff instead of duplicates in each module)
