### PR TITLE
Handle String to Enum conversion (when Java Enums are stored as Strings in the database)

### DIFF
--- a/jOOQ/src/main/java/org/jooq/tools/Convert.java
+++ b/jOOQ/src/main/java/org/jooq/tools/Convert.java
@@ -516,6 +516,14 @@ public final class Convert {
                 else if ((fromClass == Long.class || fromClass == long.class) && java.util.Date.class.isAssignableFrom(toClass)) {
                     return toDate((Long) from, toClass);
                 }
+
+                else if ((fromClass == String.class) && java.lang.Enum.class.isAssignableFrom(toClass)) {
+                    try {
+                        return java.lang.Enum.valueOf(toClass, (String) from);
+                    } catch (java.lang.IllegalArgumentException e) {
+                        throw fail(from, toClass);
+                    }
+                }
             }
 
             throw fail(from, toClass);


### PR DESCRIPTION
In schema-less mode, when we try to convert a record into a specific class which contains Enums, conversion will fail because jOOQ try to use the setter of the enum with a string.

E.g.

``` java
enum A {
    ENUM_A, ENUM_B
}

class A {

    private A enum;

    public void setEnum(A enum) {
        this.enum = enum;
    }

}
```

jOOQ will invoke the method setEnum("ENUM_A") or setEnum("ENUM_B").

The goal of this patch is to make jOOQ call setters with the good parameter type.
