### PR TITLE
Fix for insert into Postgres String Array when strings contained " or \.

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/DefaultBindContext.java
+++ b/jOOQ/src/main/java/org/jooq/impl/DefaultBindContext.java
@@ -336,7 +336,7 @@ class DefaultBindContext extends AbstractBindContext {
             }
             else {
                 sb.append("\"");
-                sb.append(o.toString().replaceAll("\"", "\"\""));
+                sb.append(o.toString().replace("\\", "\\\\").replace("\"", "\\\""));
                 sb.append("\"");
             }
 

--- a/jOOQ/src/test/java/org/jooq/impl/PostgresArrayEscapingTest.java
+++ b/jOOQ/src/test/java/org/jooq/impl/PostgresArrayEscapingTest.java
@@ -30,4 +30,14 @@ public class PostgresArrayEscapingTest {
     public void nulls() {
         assertEquals("{null}", DefaultBindContext.postgresArrayString(new Object[]{null}));
     }
+
+    @Test
+    public void stringsWithQuotesShouldBeEscaped() {
+        assertEquals("{\"\\\"foo\"}", DefaultBindContext.postgresArrayString(new String[]{"\"foo"}));
+    }
+
+    @Test
+    public void stringsWithBackslashesShouldBeEncoded() {
+        assertEquals("{\"\\\\foo\"}", DefaultBindContext.postgresArrayString(new String[]{"\\foo"}));
+    }
 }


### PR DESCRIPTION
Having quotes (") in a string in a Postgres Array caused the following exception. And backslashes in such string were stripped. -- Fixed.

Exception in thread "main" org.jooq.exception.DataAccessException: SQL [insert into "<SNIP>" (<SNIP>) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::varchar[], ?, ?)]; ERROR: malformed array literal: "{"""this will not work"}"
    at org.jooq.impl.Util.translate(Util.java:621)
    at org.jooq.impl.DefaultExecuteContext.sqlException(DefaultExecuteContext.java:360)
    at org.jooq.impl.AbstractQuery.execute(AbstractQuery.java:176)
    at org.jooq.impl.InsertImpl.execute(InsertImpl.java:95)
    <SNIP>
Caused by: org.postgresql.util.PSQLException: ERROR: malformed array literal: "{"""this will not work"}"
    at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2103)
    at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:1836)
    at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:257)
    at org.postgresql.jdbc2.AbstractJdbc2Statement.execute(AbstractJdbc2Statement.java:512)
    at org.postgresql.jdbc2.AbstractJdbc2Statement.executeWithFlags(AbstractJdbc2Statement.java:388)
    at org.postgresql.jdbc2.AbstractJdbc2Statement.execute(AbstractJdbc2Statement.java:381)
    at org.jooq.impl.DataSourcePreparedStatement.execute(DataSourcePreparedStatement.java:86)
    at org.jooq.impl.AbstractQuery.execute(AbstractQuery.java:219)
    at org.jooq.impl.InsertQueryImpl.execute(InsertQueryImpl.java:487)
    at org.jooq.impl.AbstractQuery.execute(AbstractQuery.java:172)
    ... 2 more
