### PR TITLE
Prevent IndexOutOfBoundsException

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/Utils.java
+++ b/jOOQ/src/main/java/org/jooq/impl/Utils.java
@@ -736,7 +736,7 @@ final class Utils {
                 for (; i < sqlChars.length && sqlChars[i] != '\r' && sqlChars[i] != '\n'; render.sql(sqlChars[i++]));
 
                 // Consume the newline character
-                render.sql(sqlChars[i]);
+                if (i < sqlChars.length) render.sql(sqlChars[i]);
             }
 
             // [#1797] Skip content inside of multi-line comments, e.g.


### PR DESCRIPTION
A query like "SELECT 1 FROM DUAL; -- some comment" causes an exception as Utils.renderAndBind is explicitly looking for the newline character, which never comes.
Normally, and I think according to the standard, a single line comment should be terminated by a newline. However, it should not be harmful to tolerate this case.

... the commit message of the second commit makes no sense... however, the check is reasonable as the i = sqlChars.length if we encountered the end of the string instead of a newline...
