### PR TITLE
Support UUID in Postgres arrays

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/Utils.java
+++ b/jOOQ/src/main/java/org/jooq/impl/Utils.java
@@ -2254,6 +2254,9 @@ final class Utils {
         else if (type == ULong.class) {
             return (T) ULong.valueOf(string);
         }
+        else if(type == UUID.class) {
+            return (T) UUID.fromString(string);
+        }
         else if (type.isArray()) {
             return (T) pgNewArray(type, string);
         }


### PR DESCRIPTION
Simple change to postgres array parsing to support its native UUID type
