### PR TITLE
Fix for issue #2374

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/AbstractStoreQuery.java
+++ b/jOOQ/src/main/java/org/jooq/impl/AbstractStoreQuery.java
@@ -35,6 +35,7 @@
  */
 package org.jooq.impl;
 
+import static org.jooq.impl.Utils.field;
 import static org.jooq.impl.Utils.fieldArray;
 import static org.jooq.util.sqlite.SQLiteFactory.rowid;
 
@@ -383,6 +384,21 @@ abstract class AbstractStoreQuery<R extends Record> extends AbstractQuery implem
                                          .where(field.in(ids))
                                          .fetchInto(into);
                 }
+
+            // We don't have an identity, maybe because the table has been dynamically created
+            // with Factory#tableByName(). In that case return an "anonymous" result which contains
+            // the generated ids.
+            } else {
+                final Field<Object> idField = field(null);
+                final ResultImpl<R> result = new ResultImpl<R>(configuration, idField);
+
+                for (final Object value : values) {
+                    final Record record = Utils.newRecord(RecordImpl.class, new Field[] {idField});
+                    record.setValue(idField, value);
+                    result.addRecord((R) record);
+                }
+
+                returned = result;
             }
         }
     }


### PR DESCRIPTION
In case no identity field can be determined the generated IDs are returned in a new "anonymous" result.
