### PR TITLE
NullPointerException in AbstractResultQuery.fetchOneMap()

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/AbstractResultQuery.java
+++ b/jOOQ/src/main/java/org/jooq/impl/AbstractResultQuery.java
@@ -554,7 +554,8 @@ abstract class AbstractResultQuery<R extends Record> extends AbstractQuery imple
 
     @Override
     public final Map<String, Object> fetchOneMap() {
-        return fetchOne().intoMap();
+		R record = fetchOne();
+		return record == null ? null : record.intoMap();
     }
 
     @Override


### PR DESCRIPTION
hello, i have some problem.

My environment jOOQ 3.0.0 , mysql, empty table wn_module 
point -> empty table fetchOneMap() 

see my test code 

```
@Test
public void connectionPoolTest() {
    Connection conn = null;
    try {
        conn = ds.getConnection();
        DSLContext create = DSL.using(conn, SQLDialect.MYSQL);
        System.out.println(" result => " + create.select().from(DSL.tableByName("wn_module")).fetchOneMap());
    } catch (SQLException e) {
        logger.error(e.getMessage(), e);
    } finally {
        DBUtil.closeQuietly(conn);
    }
}
```

Raise NPE(NullPointerException) 

```
java.lang.NullPointerException
at org.jooq.impl.AbstractResultQuery.fetchOneMap(AbstractResultQuery.java:495)
at org.jooq.impl.SelectImpl.fetchOneMap(SelectImpl.java:1108)
```

Reason `fetchOne()` is null 
Like this should be changed. 

AbstractResultQuery.java(:557) (master branch)

```
@Override
public final Map<String, Object> fetchOneMap() {
    R record = fetchOne();
    return record == null ? null : record.intoMap();
}
```

regards, Bohyung kim 
