### PR TITLE
Use maven logging

### DIFF
--- a/jOOQ-codegen-maven/pom.xml
+++ b/jOOQ-codegen-maven/pom.xml
@@ -73,6 +73,21 @@
             <artifactId>maven-project</artifactId>
             <version>2.2.1</version>
             <type>jar</type>
+	</dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.7</version>
+        </dependency>
+
+        <!--
+         | Necessary because jOOR tries to access the classes of all fields in
+         | JooqLogger
+        -->
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
         </dependency>
     </dependencies>
 </project>

--- a/jOOQ-codegen-maven/src/main/java/org/jooq/util/maven/Plugin.java
+++ b/jOOQ-codegen-maven/src/main/java/org/jooq/util/maven/Plugin.java
@@ -51,6 +51,9 @@ import org.jooq.util.jaxb.Configuration;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
+import org.jooq.tools.reflect.Reflect;
+import org.jooq.util.JavaGenerator;
+import org.slf4j.Logger;
 
 /**
  * @goal generate
@@ -87,6 +90,16 @@ public class Plugin extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException {
         try {
+
+            // [#3273] Use maven log
+            Logger log = Reflect.on(getLog()).as(Logger.class);
+
+            Reflect.on(GenerationTool.class).field("log")
+                .set("slf4j", log)
+                .set("supportsInfo", true);
+            Reflect.on(JavaGenerator.class).field("log")
+                .set("slf4j", log)
+                .set("supportsInfo", true);
 
             // [#2887] Patch relative paths to take plugin execution basedir into accountcd joo
             String dir = generator.getTarget().getDirectory();


### PR DESCRIPTION
jooq-codegen-maven uses jooq-codegen which itself uses JooqLogger for logging which means the default Maven loggig is not used. This patch replaces the default logging mechanism with the `MavenProject.getLog` instance which makes the log output readable again.
