### PR TITLE
A small change to simplify the methodology of selecting mock resultsets from MockDataProviders

### DIFF
--- a/jOOQ/src/main/java/org/jooq/tools/jdbc/MockDataProvider.java
+++ b/jOOQ/src/main/java/org/jooq/tools/jdbc/MockDataProvider.java
@@ -141,5 +141,5 @@ public interface MockDataProvider {
      * @throws SQLException A <code>SQLException</code> that is passed through
      *             to jOOQ.
      */
-    MockResult[] execute(MockExecuteContext ctx) throws SQLException;
+    abstract MockResult[] execute(MockExecuteContext ctx) throws SQLException;
 }

--- a/jOOQ/src/main/java/org/jooq/tools/jdbc/SelectableMockConnection.java
+++ b/jOOQ/src/main/java/org/jooq/tools/jdbc/SelectableMockConnection.java
@@ -44,7 +44,6 @@ import java.sql.Array;
 import java.sql.Blob;
 import java.sql.CallableStatement;
 import java.sql.Clob;
-import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.NClob;
 import java.sql.PreparedStatement;
@@ -90,7 +89,7 @@ import java.util.Properties;
  *
  * @author Lukas Eder
  */
-public class SelectableSelectableMockConnection extends JDBC41Connection implements Connection {
+public class SelectableMockConnection extends MockConnection {
 
     private final SelectableMockDataProvider data;
     private boolean                isClosed;
@@ -99,7 +98,8 @@ public class SelectableSelectableMockConnection extends JDBC41Connection impleme
     	data.setSelection(value);
     }
 
-    public SelectableMockConnection(MockDataProvider data) {
+    public SelectableMockConnection(SelectableMockDataProvider data) {
+        super(data);
         this.data = data;
     }
 

--- a/jOOQ/src/main/java/org/jooq/tools/jdbc/SelectableMockDataProvider.java
+++ b/jOOQ/src/main/java/org/jooq/tools/jdbc/SelectableMockDataProvider.java
@@ -144,7 +144,8 @@ public abstract class SelectableMockDataProvider implements MockDataProvider {
      * @throws SQLException A <code>SQLException</code> that is passed through
      *             to jOOQ.
      */
-    abstract MockResult[] execute(MockExecuteContext ctx) throws SQLException;
+    @Override
+    public abstract MockResult[] execute(MockExecuteContext ctx) throws SQLException;
 
     /**
      * Sets a selection value so that it can be used by the execute() method to

--- a/jOOQ/src/test/java/org/jooq/test/MockTest.java
+++ b/jOOQ/src/test/java/org/jooq/test/MockTest.java
@@ -49,12 +49,14 @@ import static org.jooq.test.data.Table2.FIELD_ID2;
 import static org.jooq.test.data.Table2.FIELD_NAME2;
 import static org.jooq.test.data.Table2.TABLE2;
 import static org.jooq.test.data.Table3.FIELD_NAME3;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.RandomAccessFile;
 import java.sql.SQLException;
+import java.util.Date;
 import java.util.List;
 
 import org.jooq.Constants;
@@ -75,6 +77,8 @@ import org.jooq.tools.jdbc.MockDataProvider;
 import org.jooq.tools.jdbc.MockExecuteContext;
 import org.jooq.tools.jdbc.MockFileDatabase;
 import org.jooq.tools.jdbc.MockResult;
+import org.jooq.tools.jdbc.SelectableMockConnection;
+import org.jooq.tools.jdbc.SelectableMockDataProvider;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -425,5 +429,58 @@ public class MockTest extends AbstractTest {
         assertEquals("x", r2.getValue(0, 0));
         assertEquals("y", r2.getValue(0, 1));
         assertEquals("z", r2.getValue(0, 2));
+    }
+
+    private static final int RESULTONE = 0;
+    private static final int RESULTTWO = 1;
+    private static final int RESULTSTRINGS = 3;
+
+    private class SelectableResults extends SelectableMockDataProvider {
+        @Override
+        public MockResult[] execute(MockExecuteContext ctx) throws SQLException {
+            switch(selector) {
+                case RESULTONE:
+                    return new MockResult[] {
+                        new MockResult(1, resultOne)
+                    };
+                case RESULTTWO:
+                    return new MockResult[] {
+                        new MockResult(1, resultTwo)
+                    };
+                case RESULTSTRINGS:
+                    return new MockResult[] {
+                        new MockResult(1, resultStrings)
+                    };
+                default:
+                    return new MockResult[] {
+                        new MockResult(0, resultOne)
+                    };
+            }
+        }
+    }
+
+    @Test
+    public void testSelectableMockDataProvider() {
+        SelectableMockDataProvider provider = new SelectableResults();
+        SelectableMockConnection sConn = new SelectableMockConnection(provider);
+        DSLContext selectCtx = DSL.using(sConn, SQLDialect.POSTGRES);
+        sConn.setSelection(RESULTONE);
+        Record resOne = selectCtx.select(TABLE1.fields()).from(TABLE1).fetchOne();
+        assertNotNull("The first selectable result should not be null.", resOne);
+        assertEquals("resultOne.field0 should be equal", resultOne.getValue(0, 0), resOne.getValue(TABLE1.fields()[0], Integer.class));
+        assertEquals("resultOne.field1 should be equal", resultOne.getValue(0, 1), resOne.getValue(TABLE1.fields()[1], String.class));
+        assertEquals("resultOne.field2 should be equal", resultOne.getValue(0, 2), resOne.getValue(TABLE1.fields()[2], Date.class));
+        sConn.setSelection(RESULTTWO);
+        Record resTwo = selectCtx.select(TABLE1.fields()).from(TABLE1).fetchAny();
+        assertNotNull("The first selectable result should not be null.", resTwo);
+        assertEquals("resultTwo.field0 should be equal", resultTwo.getValue(0, 0), resTwo.getValue(TABLE1.fields()[0], Integer.class));
+        assertEquals("resultTwo.field1 should be equal", resultTwo.getValue(0, 1), resTwo.getValue(TABLE1.fields()[1], String.class));
+        assertEquals("resultTwo.field2 should be equal", resultTwo.getValue(0, 2), resTwo.getValue(TABLE1.fields()[2], Date.class));
+        sConn.setSelection(RESULTSTRINGS);
+        Record resThree = selectCtx.select(FIELD_NAME1, FIELD_NAME2, FIELD_NAME3).from(TABLE1).fetchAny();
+        assertNotNull("The first selectable result should not be null.", resThree);
+        assertEquals("resultStrings.field0 should be equal", resultStrings.getValue(0, 0), resThree.getValue(0));
+        assertEquals("resultStrings.field1 should be equal", resultStrings.getValue(0, 1), resThree.getValue(1));
+        assertEquals("resultStrings.field2 should be equal", resultStrings.getValue(0, 2), resThree.getValue(2));
     }
 }


### PR DESCRIPTION
The new abstract class SelectableMockDataProvider and new class SelectableMockConnection extend the functionality of the existing MockDataProvider and MockConnection so that just prior to running a query from test code, the test code can select the appropriate results by calling SelectableMockConnection.setSelector(int). This integer value is then available to be used by the SelectableMockDataProvider implementation in order to choose the appropriate resultset to be returned for subsequent queries.
