### PR TITLE
Converted Data Type does not propagate nullable and defaulted properties.

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/DefaultDataType.java
+++ b/jOOQ/src/main/java/org/jooq/impl/DefaultDataType.java
@@ -222,11 +222,11 @@ public class DefaultDataType<T> implements DataType<T> {
     }
 
     public DefaultDataType(SQLDialect dialect, DataType<T> sqlDataType, String typeName) {
-        this(dialect, sqlDataType, sqlDataType.getType(), typeName, typeName, 0, 0, 0, true, false);
+        this(dialect, sqlDataType, sqlDataType.getType(), typeName, typeName, 0, 0, 0, sqlDataType.nullable(), sqlDataType.defaulted());
     }
 
     public DefaultDataType(SQLDialect dialect, DataType<T> sqlDataType, String typeName, String castTypeName) {
-        this(dialect, sqlDataType, sqlDataType.getType(), typeName, castTypeName, 0, 0, 0, true, false);
+        this(dialect, sqlDataType, sqlDataType.getType(), typeName, castTypeName, 0, 0, 0, sqlDataType.nullable(), sqlDataType.defaulted());
     }
 
     public DefaultDataType(SQLDialect dialect, Class<T> type, String typeName) {


### PR DESCRIPTION
ConverterDataTypes do not propagate the nullable and defaulted properties.

For instance, when using an EnumConverter from String to Enum, the generated field has the correct Enum type, but the nullable and defaulted properties are allowed true and false resp.
