### PR TITLE
Cache Record Constructor in CursorImpl

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/RecordImpl.java
+++ b/jOOQ/src/main/java/org/jooq/impl/RecordImpl.java
@@ -80,7 +80,7 @@ import org.jooq.Record22;
  */
 @Generated("This class was generated using jOOQ-tools")
 @SuppressWarnings({ "unchecked", "rawtypes" })
-class RecordImpl<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> extends AbstractRecord
+public class RecordImpl<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> extends AbstractRecord
 implements
 
     // This record implementation implements all record types. Type-safety is

--- a/jOOQ/src/main/java/org/jooq/tools/reflect/ConstructorInstantiator.java
+++ b/jOOQ/src/main/java/org/jooq/tools/reflect/ConstructorInstantiator.java
@@ -1,0 +1,25 @@
+package org.jooq.tools.reflect;
+
+import org.jooq.Field;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Created by aroger on 28/11/14.
+ */
+public class ConstructorInstantiator<T> implements RecordInstantiator<T> {
+
+
+    private final Constructor<T> constructor;
+
+    public ConstructorInstantiator(Constructor<T> constructor) {
+        this.constructor = constructor;
+    }
+
+
+    @Override
+    public T newInstance(Field<?>[] fields) throws IllegalAccessException, InvocationTargetException, InstantiationException {
+        return constructor.newInstance();
+    }
+}

--- a/jOOQ/src/main/java/org/jooq/tools/reflect/RecordInstantiator.java
+++ b/jOOQ/src/main/java/org/jooq/tools/reflect/RecordInstantiator.java
@@ -1,0 +1,12 @@
+package org.jooq.tools.reflect;
+
+import org.jooq.Field;
+
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Created by aroger on 28/11/14.
+ */
+public interface RecordInstantiator<T> {
+    T newInstance(Field<?>[] fields) throws IllegalAccessException, InvocationTargetException, InstantiationException;
+}

--- a/jOOQ/src/main/java/org/jooq/tools/reflect/RecordInstantiatorFactory.java
+++ b/jOOQ/src/main/java/org/jooq/tools/reflect/RecordInstantiatorFactory.java
@@ -1,0 +1,31 @@
+package org.jooq.tools.reflect;
+
+import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.impl.RecordImpl;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Created by aroger on 28/11/14.
+ */
+public class RecordInstantiatorFactory {
+
+
+    public static <T> RecordInstantiator<T> newInstantiator(Class<T> type) throws NoSuchMethodException {
+
+        if (type == RecordImpl.class || type == Record.class) {
+            return new RecordInstantiator<T>() {
+                @Override
+                public T newInstance(Field<?>[] fields) throws IllegalAccessException, InvocationTargetException, InstantiationException {
+                    return (T) new RecordImpl(fields);
+                }
+            };
+        }
+        Constructor<T> constructor = type.getDeclaredConstructor();
+        if (!constructor.isAccessible())
+            constructor.setAccessible(true);
+        return new ConstructorInstantiator<T>(constructor);
+    }
+}

--- a/perf.txt
+++ b/perf.txt
@@ -1,0 +1,9 @@
+original
+Benchmark                                  (db)  (limit)   Mode  Samples     Score    Error  Units
+o.s.b.d.j.JooqBenchmark.testFetchRecord    MOCK     1000  thrpt       10  2064.386 ± 32.245  ops/s
+
+
+recordinstantiator
+
+Benchmark                                  (db)  (limit)   Mode  Samples     Score    Error  Units
+o.s.b.d.j.JooqBenchmark.testFetchRecord    MOCK     1000  thrpt       10  2165.060 ± 37.453  ops/s

--- a/perf.txt
+++ b/perf.txt
@@ -1,9 +1,0 @@
-original
-Benchmark                                  (db)  (limit)   Mode  Samples     Score    Error  Units
-o.s.b.d.j.JooqBenchmark.testFetchRecord    MOCK     1000  thrpt       10  2064.386 ± 32.245  ops/s
-
-
-recordinstantiator
-
-Benchmark                                  (db)  (limit)   Mode  Samples     Score    Error  Units
-o.s.b.d.j.JooqBenchmark.testFetchRecord    MOCK     1000  thrpt       10  2165.060 ± 37.453  ops/s


### PR DESCRIPTION
When I executed the benchmark with sfm vs generated record the sfm was still faster because of the constructor lookup. 
Note that I cache the RecordInstantiator in the CursorImpl but very likely that ideally you would want to generate the RecrodInstantiator as par as generated the specified record.
That move the perf with the specified record higher that sfm as expected.

