### PR TITLE
[#3923] Four octects are sent to Postgres for each negative byte in a byte[]

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/DefaultBinding.java
+++ b/jOOQ/src/main/java/org/jooq/impl/DefaultBinding.java
@@ -767,7 +767,8 @@ public class DefaultBinding<T, U> implements Binding<T, U> {
 
         for (byte b : binary) {
             sb.append("\\\\");
-            sb.append(leftPad(toOctalString(b), 3, '0'));
+            int octal = b & 0x000000ff;
+            sb.append(leftPad(toOctalString(octal), 3, '0'));
         }
 
         return sb.toString();


### PR DESCRIPTION
When JOOQ sends array of bytes to Postgres, it uses the octal format. To do the conversion from binary byte to octal, it uses java.lang.Integer#toOctalString(int) and the byte is automatically casted to integer. It works fine with positive bytes, but not with negative ones.

For example, when [-1] is inserted, [377] should be sent to Posgresql. Instead of that, Java transforms the byte -1 to the integer -1, represented in octal as 377 377 377 377, and jOOQ sends the array [377, 377, 377, 377]!