### PR TITLE
Add support for bulk insertion in the Loader API

### DIFF
--- a/jOOQ/src/main/java/org/jooq/LoaderOptionsStep.java
+++ b/jOOQ/src/main/java/org/jooq/LoaderOptionsStep.java
@@ -211,4 +211,17 @@ public interface LoaderOptionsStep<R extends TableRecord<R>> extends LoaderSourc
     @Support
     LoaderOptionsStep<R> commitNone();
 
+    /**
+     * Run insert in bulk mode.
+     * Specially useful for insert statements.
+     * In that case, a single statement can insert multiple records in one go.
+     * There might be a limit of markers (i.e. MSSQL has 2000). In such cases the
+     * inseret statement must be executed blockwise.
+     * @param markerLimit The limit of markers. Depends on the dialect.
+     * @return
+     */
+    @Support
+    LoaderOptionsStep<R> withBulkInsert(int markerLimit);
+
+
 }


### PR DESCRIPTION
Implementing a bulk processing has shown, that our data processing is a lot faster.
For a h2 there comparison is  90sec vs.	20sec
and for a mssql 43min vs. 5min.

Especially when communicating to a remote instance, sending as much data as possible makes a huge different.

Please check if you can implement something like I did and bring it to a productive state.
Currently it is just a POC.

Thanks.
Detlef