### PR TITLE
Incorrect IntelliJ directory listings in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /target
-/**/*.iml
-/**/.idea
+*.iml
+.idea


### PR DESCRIPTION
Trivial, I know, but this corrects .gitignore when the entire jOOQ project is imported into IntelliJ