### PR TITLE
Add <T> DSL.coalesce(Field<T>, T)

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/DSL.java
+++ b/jOOQ/src/main/java/org/jooq/impl/DSL.java
@@ -7418,6 +7418,17 @@ public class DSL {
     }
 
     /**
+     * Gets the Oracle-style <code>COALESCE(field, value)</code>
+     * function.
+     *
+     * @see #coalesce(Field, Field...)
+     */
+    @Support
+    public static <T> Field<T> coalesce(Field<T> field, T value) {
+        return coalesce(field, Utils.field(value));
+    }
+
+    /**
      * Gets the Oracle-style <code>COALESCE(field1, field2, ... , field n)</code>
      * function.
      * <p>


### PR DESCRIPTION
Additional convenience method for something like `select sum(col)`.  Without this method, I have to make assumptions about the return value (BigDecimal) and cast.  With the method, any Field/Value pairing will have the correctly-typed return.