### PR TITLE
Update Convert.java

### DIFF
--- a/jOOQ/src/main/java/org/jooq/tools/Convert.java
+++ b/jOOQ/src/main/java/org/jooq/tools/Convert.java
@@ -138,7 +138,7 @@ public final class Convert {
         falseValues.add("OFF");
         falseValues.add("disabled");
         falseValues.add("DISABLED");
-        trueValues.add("f"); //added for Vertica DB, Vertica return t or f
+        falseValues.add("f"); //added for Vertica DB, Vertica return t or f
 
         TRUE_VALUES = Collections.unmodifiableSet(trueValues);
         FALSE_VALUES = Collections.unmodifiableSet(falseValues);

--- a/jOOQ/src/main/java/org/jooq/tools/Convert.java
+++ b/jOOQ/src/main/java/org/jooq/tools/Convert.java
@@ -124,6 +124,7 @@ public final class Convert {
         trueValues.add("ON");
         trueValues.add("enabled");
         trueValues.add("ENABLED");
+        trueValues.add("t"); //added for Vertica DB, Vertica return t or f
 
         falseValues.add("0");
         falseValues.add("0.0");
@@ -137,6 +138,7 @@ public final class Convert {
         falseValues.add("OFF");
         falseValues.add("disabled");
         falseValues.add("DISABLED");
+        trueValues.add("f"); //added for Vertica DB, Vertica return t or f
 
         TRUE_VALUES = Collections.unmodifiableSet(trueValues);
         FALSE_VALUES = Collections.unmodifiableSet(falseValues);


### PR DESCRIPTION
boolean value "t" or "f" returned by Vertica and it is missing in converter, hence source code generation is faulty which always assigns true to all Table entity fields