### PR TITLE
Relax type constraint of DSL.shl() and DSL.shr()

### DIFF
--- a/jOOQ/src/main/java/org/jooq/Field.java
+++ b/jOOQ/src/main/java/org/jooq/Field.java
@@ -856,7 +856,7 @@ public interface Field<T> extends SelectField<T>, GroupField {
      * @see DSL#power(Field, Number)
      */
     @Support({ CUBRID, FIREBIRD, H2, HSQLDB, MARIADB, MYSQL, POSTGRES, SQLITE })
-    Field<T> shl(T value);
+    Field<T> shl(Number value);
 
     /**
      * The bitwise left shift operator.
@@ -865,7 +865,7 @@ public interface Field<T> extends SelectField<T>, GroupField {
      * @see DSL#power(Field, Number)
      */
     @Support({ CUBRID, FIREBIRD, H2, HSQLDB, MARIADB, MYSQL, POSTGRES, SQLITE })
-    Field<T> shl(Field<T> value);
+    Field<T> shl(Field<? extends Number> value);
 
     /**
      * The bitwise right shift operator.
@@ -874,7 +874,7 @@ public interface Field<T> extends SelectField<T>, GroupField {
      * @see DSL#power(Field, Number)
      */
     @Support({ CUBRID, FIREBIRD, H2, HSQLDB, MARIADB, MYSQL, POSTGRES, SQLITE })
-    Field<T> shr(T value);
+    Field<T> shr(Number value);
 
     /**
      * The bitwise right shift operator.
@@ -883,7 +883,7 @@ public interface Field<T> extends SelectField<T>, GroupField {
      * @see DSL#power(Field, Number)
      */
     @Support({ CUBRID, FIREBIRD, H2, HSQLDB, MARIADB, MYSQL, POSTGRES, SQLITE })
-    Field<T> shr(Field<T> value);
+    Field<T> shr(Field<? extends Number> value);
 
     // ------------------------------------------------------------------------
     // NULL predicates

--- a/jOOQ/src/main/java/org/jooq/impl/AbstractField.java
+++ b/jOOQ/src/main/java/org/jooq/impl/AbstractField.java
@@ -542,26 +542,26 @@ abstract class AbstractField<T> extends AbstractQueryPart implements Field<T> {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
-    public final Field<T> shl(T value) {
-        return DSL.shl((Field) this, (Field) val(value, this));
+    public final Field<T> shl(Number value) {
+        return DSL.shl((Field) this, (Field) Utils.field(value));
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
-    public final Field<T> shl(Field<T> value) {
-        return DSL.shl((Field) this, (Field) value);
+    public final Field<T> shl(Field<? extends Number> value) {
+        return DSL.shl((Field) this, value);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
-    public final Field<T> shr(T value) {
-        return DSL.shr((Field) this, (Field) val(value, this));
+    public final Field<T> shr(Number value) {
+        return DSL.shr((Field) this, (Field) Utils.field(value));
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
-    public final Field<T> shr(Field<T> value) {
-        return DSL.shr((Field) this, (Field) value);
+    public final Field<T> shr(Field<? extends Number> value) {
+        return DSL.shr((Field) this, value);
     }
 
     // ------------------------------------------------------------------------

--- a/jOOQ/src/main/java/org/jooq/impl/DSL.java
+++ b/jOOQ/src/main/java/org/jooq/impl/DSL.java
@@ -9959,7 +9959,7 @@ public class DSL {
      * @see #power(Field, Number)
      */
     @Support({ CUBRID, FIREBIRD, H2, HSQLDB, MARIADB, MYSQL, POSTGRES, SQLITE })
-    public static <T extends Number> Field<T> shl(T value1, T value2) {
+    public static <T extends Number> Field<T> shl(T value1, Number value2) {
         return shl(Utils.field(value1), Utils.field(value2));
     }
 
@@ -9970,7 +9970,7 @@ public class DSL {
      * @see #power(Field, Number)
      */
     @Support({ CUBRID, FIREBIRD, H2, HSQLDB, MARIADB, MYSQL, POSTGRES, SQLITE })
-    public static <T extends Number> Field<T> shl(T value1, Field<T> value2) {
+    public static <T extends Number> Field<T> shl(T value1, Field<? extends Number> value2) {
         return shl(Utils.field(value1), nullSafe(value2));
     }
 
@@ -9981,7 +9981,7 @@ public class DSL {
      * @see #power(Field, Number)
      */
     @Support({ CUBRID, FIREBIRD, H2, HSQLDB, MARIADB, MYSQL, POSTGRES, SQLITE })
-    public static <T extends Number> Field<T> shl(Field<T>value1, T value2) {
+    public static <T extends Number> Field<T> shl(Field<T>value1, Number value2) {
         return shl(nullSafe(value1), Utils.field(value2));
     }
 
@@ -9995,7 +9995,7 @@ public class DSL {
      * @see #power(Field, Field)
      */
     @Support({ CUBRID, FIREBIRD, H2, HSQLDB, MARIADB, MYSQL, POSTGRES, SQLITE })
-    public static <T extends Number> Field<T> shl(Field<T> field1, Field<T> field2) {
+    public static <T extends Number> Field<T> shl(Field<T> field1, Field<? extends Number> field2) {
         return new Expression<T>(ExpressionOperator.SHL, nullSafe(field1), nullSafe(field2));
     }
 
@@ -10006,7 +10006,7 @@ public class DSL {
      * @see #power(Field, Number)
      */
     @Support({ CUBRID, FIREBIRD, H2, HSQLDB, MARIADB, MYSQL, POSTGRES, SQLITE })
-    public static <T extends Number> Field<T> shr(T value1, T value2) {
+    public static <T extends Number> Field<T> shr(T value1, Number value2) {
         return shr(Utils.field(value1), Utils.field(value2));
     }
 
@@ -10017,7 +10017,7 @@ public class DSL {
      * @see #power(Field, Number)
      */
     @Support({ CUBRID, FIREBIRD, H2, HSQLDB, MARIADB, MYSQL, POSTGRES, SQLITE })
-    public static <T extends Number> Field<T> shr(T value1, Field<T> value2) {
+    public static <T extends Number> Field<T> shr(T value1, Field<? extends Number> value2) {
         return shr(Utils.field(value1), nullSafe(value2));
     }
 
@@ -10028,7 +10028,7 @@ public class DSL {
      * @see #power(Field, Number)
      */
     @Support({ CUBRID, FIREBIRD, H2, HSQLDB, MARIADB, MYSQL, POSTGRES, SQLITE })
-    public static <T extends Number> Field<T> shr(Field<T> value1, T value2) {
+    public static <T extends Number> Field<T> shr(Field<T> value1, Number value2) {
         return shr(nullSafe(value1), Utils.field(value2));
     }
 
@@ -10042,7 +10042,7 @@ public class DSL {
      * @see #power(Field, Field)
      */
     @Support({ CUBRID, H2, FIREBIRD, HSQLDB, MARIADB, MYSQL, POSTGRES, SQLITE })
-    public static <T extends Number> Field<T> shr(Field<T> field1, Field<T> field2) {
+    public static <T extends Number> Field<T> shr(Field<T> field1, Field<? extends Number> field2) {
         return new Expression<T>(ExpressionOperator.SHR, nullSafe(field1), nullSafe(field2));
     }
 

--- a/jOOQ/src/test/java/org/jooq/test/BasicTest.java
+++ b/jOOQ/src/test/java/org/jooq/test/BasicTest.java
@@ -430,23 +430,23 @@ public class BasicTest extends AbstractTest {
             DSL.second((java.util.Date) null),
             DSL.second((Field<java.util.Date>) null));
         assertEquals(
-            DSL.shl((Integer) null, (Integer) null),
-            DSL.shl((Integer) null, (Field<Integer>) null));
+            DSL.shl((Long) null, (Integer) null),
+            DSL.shl((Long) null, (Field<Integer>) null));
         assertEquals(
-            DSL.shl((Integer) null, (Integer) null),
-            DSL.shl((Field<Integer>) null, (Integer) null));
+            DSL.shl((Long) null, (Integer) null),
+            DSL.shl((Field<Long>) null, (Integer) null));
         assertEquals(
-            DSL.shl((Integer) null, (Integer) null),
-            DSL.shl((Field<Integer>) null, (Field<Integer>) null));
+            DSL.shl((Long) null, (Integer) null),
+            DSL.shl((Field<Long>) null, (Field<Integer>) null));
         assertEquals(
-            DSL.shr((Integer) null, (Integer) null),
-            DSL.shr((Integer) null, (Field<Integer>) null));
+            DSL.shr((Long) null, (Integer) null),
+            DSL.shr((Long) null, (Field<Integer>) null));
         assertEquals(
-            DSL.shr((Integer) null, (Integer) null),
-            DSL.shr((Field<Integer>) null, (Integer) null));
+            DSL.shr((Long) null, (Integer) null),
+            DSL.shr((Field<Long>) null, (Integer) null));
         assertEquals(
-            DSL.shr((Integer) null, (Integer) null),
-            DSL.shr((Field<Integer>) null, (Field<Integer>) null));
+            DSL.shr((Long) null, (Integer) null),
+            DSL.shr((Field<Long>) null, (Field<Integer>) null));
         assertEquals(
             DSL.sign((Integer) null),
             DSL.sign((Field<Integer>) null));

--- a/jOOQ/src/test/java/org/jooq/test/BasicTest.java
+++ b/jOOQ/src/test/java/org/jooq/test/BasicTest.java
@@ -159,6 +159,12 @@ public class BasicTest extends AbstractTest {
         assertEquals(
             FIELD_ID1.sub((Integer) null),
             FIELD_ID1.sub((Field<Integer>) null));
+        assertEquals(
+            FIELD_ID1.shl((Long) null),
+            FIELD_ID1.shl((Field<Long>) null));
+        assertEquals(
+            FIELD_ID1.shr((Long) null),
+            FIELD_ID1.shr((Field<Long>) null));
 
         // Standalone functions created from the factory
         // ---------------------------------------------


### PR DESCRIPTION
Operands of `shl` and `shr` don't need to be same type.