### PR TITLE
Result.formatHTML() doesn't escape HTML content, which might produce XSS vulnerabilities

### DIFF
--- a/jOOQ-codegen-maven/pom.xml
+++ b/jOOQ-codegen-maven/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jooq</groupId>
         <artifactId>jooq-parent</artifactId>
-        <version>3.6.2</version>
+        <version>3.6.3-SNAPSHOT</version>
     </parent>
     
     <groupId>org.jooq</groupId>

--- a/jOOQ-codegen/pom.xml
+++ b/jOOQ-codegen/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jooq</groupId>
         <artifactId>jooq-parent</artifactId>
-        <version>3.6.2</version>
+        <version>3.6.3-SNAPSHOT</version>
     </parent>
     
     <groupId>org.jooq</groupId>

--- a/jOOQ-examples/jOOQ-academy/pom.xml
+++ b/jOOQ-examples/jOOQ-academy/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <org.jooq.version>3.6.2</org.jooq.version>
+        <org.jooq.version>3.6.3-SNAPSHOT</org.jooq.version>
 		<h2.version>1.4.181</h2.version>
     </properties>
     

--- a/jOOQ-examples/jOOQ-codegen-gradle/build.gradle
+++ b/jOOQ-examples/jOOQ-codegen-gradle/build.gradle
@@ -49,7 +49,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.jooq:jooq:3.6.2'
+    compile 'org.jooq:jooq:3.6.3-SNAPSHOT'
 
     runtime 'com.h2database:h2:1.4.177'
     testCompile 'junit:junit:4.11'
@@ -62,7 +62,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'org.jooq:jooq-codegen:3.6.2'
+        classpath 'org.jooq:jooq-codegen:3.6.3-SNAPSHOT'
         classpath 'com.h2database:h2:1.4.177'
     }
 }

--- a/jOOQ-examples/jOOQ-flyway-example/pom.xml
+++ b/jOOQ-examples/jOOQ-flyway-example/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <org.springframework.version>3.2.6.RELEASE</org.springframework.version>
-        <org.jooq.version>3.6.2</org.jooq.version>
+        <org.jooq.version>3.6.3-SNAPSHOT</org.jooq.version>
         <org.h2.version>1.4.181</org.h2.version>
 
         <db.url>jdbc:h2:~/flyway-test</db.url>

--- a/jOOQ-examples/jOOQ-javaee-example/pom.xml
+++ b/jOOQ-examples/jOOQ-javaee-example/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <org.jooq.version>3.6.2</org.jooq.version>
+        <org.jooq.version>3.6.3-SNAPSHOT</org.jooq.version>
         <org.h2.version>1.3.173</org.h2.version>
         <java.version>1.8</java.version>
         

--- a/jOOQ-examples/jOOQ-javafx-example/pom.xml
+++ b/jOOQ-examples/jOOQ-javafx-example/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <org.springframework.version>3.2.6.RELEASE</org.springframework.version>
-        <org.jooq.version>3.6.2</org.jooq.version>
+        <org.jooq.version>3.6.3-SNAPSHOT</org.jooq.version>
         <org.h2.version>1.4.181</org.h2.version>
     </properties>
     

--- a/jOOQ-examples/jOOQ-jax-rs-example/pom.xml
+++ b/jOOQ-examples/jOOQ-jax-rs-example/pom.xml
@@ -10,7 +10,7 @@
     <version>1.0</version>
     
     <properties>
-        <org.jooq.version>3.6.2</org.jooq.version>
+        <org.jooq.version>3.6.3-SNAPSHOT</org.jooq.version>
     </properties>
 
     <build>

--- a/jOOQ-examples/jOOQ-nashorn-example/pom.xml
+++ b/jOOQ-examples/jOOQ-nashorn-example/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <org.springframework.version>3.2.6.RELEASE</org.springframework.version>
-        <org.jooq.version>3.6.2</org.jooq.version>
+        <org.jooq.version>3.6.3-SNAPSHOT</org.jooq.version>
         <org.h2.version>1.4.181</org.h2.version>
     </properties>
     

--- a/jOOQ-examples/jOOQ-oracle-example/pom.xml
+++ b/jOOQ-examples/jOOQ-oracle-example/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <org.jooq.version>3.6.2</org.jooq.version>
+        <org.jooq.version>3.6.3-SNAPSHOT</org.jooq.version>
         <db.oracle.version>11</db.oracle.version>
     </properties>
 

--- a/jOOQ-examples/jOOQ-spring-example/pom.xml
+++ b/jOOQ-examples/jOOQ-spring-example/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <org.springframework.version>4.1.2.RELEASE</org.springframework.version>
-        <org.jooq.version>3.6.2</org.jooq.version>
+        <org.jooq.version>3.6.3-SNAPSHOT</org.jooq.version>
         <org.h2.version>1.4.181</org.h2.version>
 		<java.version>1.8</java.version>
     </properties>

--- a/jOOQ-examples/jOOQ-spring-guice-example/pom.xml
+++ b/jOOQ-examples/jOOQ-spring-guice-example/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <org.springframework.version>4.1.2.RELEASE</org.springframework.version>
-        <org.jooq.version>3.6.2</org.jooq.version>
+        <org.jooq.version>3.6.3-SNAPSHOT</org.jooq.version>
         <org.h2.version>1.4.181</org.h2.version>
     </properties>
 

--- a/jOOQ-examples/jOOQ-vertabelo-example/pom.xml
+++ b/jOOQ-examples/jOOQ-vertabelo-example/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <org.springframework.version>3.2.6.RELEASE</org.springframework.version>
-        <org.jooq.version>3.6.2</org.jooq.version>
+        <org.jooq.version>3.6.3-SNAPSHOT</org.jooq.version>
         <org.h2.version>1.4.181</org.h2.version>
     </properties>
     

--- a/jOOQ-meta-extensions/pom.xml
+++ b/jOOQ-meta-extensions/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jooq</groupId>
         <artifactId>jooq-parent</artifactId>
-        <version>3.6.2</version>
+        <version>3.6.3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jooq</groupId>

--- a/jOOQ-meta/pom.xml
+++ b/jOOQ-meta/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jooq</groupId>
         <artifactId>jooq-parent</artifactId>
-        <version>3.6.2</version>
+        <version>3.6.3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jooq</groupId>

--- a/jOOQ-release/release/template/maven-install.bat
+++ b/jOOQ-release/release/template/maven-install.bat
@@ -1,5 +1,5 @@
 @echo off
-set VERSION=3.6.2
+set VERSION=3.6.3-SNAPSHOT
 
 if exist jOOQ-javadoc\jooq-%VERSION%-javadoc.jar (
   set JAVADOC_JOOQ=-Djavadoc=jOOQ-javadoc\jooq-%VERSION%-javadoc.jar

--- a/jOOQ-release/release/template/maven-install.sh
+++ b/jOOQ-release/release/template/maven-install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-VERSION=3.6.2
+VERSION=3.6.3-SNAPSHOT
 
 if [ -f jOOQ-javadoc/jooq-$VERSION-javadoc.jar ]; then
   JAVADOC_JOOQ=-Djavadoc=jOOQ-javadoc/jooq-$VERSION-javadoc.jar

--- a/jOOQ-scala/pom.xml
+++ b/jOOQ-scala/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jooq</groupId>
         <artifactId>jooq-parent</artifactId>
-        <version>3.6.2</version>
+        <version>3.6.3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jooq</groupId>
@@ -69,7 +69,7 @@
             <plugin>
                 <groupId>org.jooq</groupId>
                 <artifactId>jooq-codegen-maven</artifactId>
-                <version>3.6.2</version>
+                <version>3.6.3-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>exec1</id>

--- a/jOOQ/pom.xml
+++ b/jOOQ/pom.xml
@@ -143,6 +143,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.1</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <version>1.2.16</version>
@@ -194,13 +200,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.6.1</version>
-            <type>jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.1</version>
             <type>jar</type>
             <scope>test</scope>
         </dependency>

--- a/jOOQ/pom.xml
+++ b/jOOQ/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jooq</groupId>
         <artifactId>jooq-parent</artifactId>
-        <version>3.6.2</version>
+        <version>3.6.3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jooq</groupId>

--- a/jOOQ/src/main/java/org/jooq/impl/HtmlWriter.java
+++ b/jOOQ/src/main/java/org/jooq/impl/HtmlWriter.java
@@ -1,0 +1,56 @@
+package org.jooq.impl;
+
+import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.exception.IOException;
+
+import java.io.Writer;
+import java.util.List;
+
+class HtmlWriter<R extends Record>  {
+
+    HtmlWriter(Fields<R> fields, List<R> records) {
+        this.fields = fields;
+        this.records = records;
+    }
+
+    private final Fields<R>   fields;
+    private final List<R> records;
+
+    final void formatHTML(Writer writer) {
+        try {
+            writer.append("<table>");
+            writer.append("<thead>");
+            writer.append("<tr>");
+
+            for (Field<?> field : fields.fields) {
+                writer.append("<th>");
+                writer.append(field.getName());
+                writer.append("</th>");
+            }
+
+            writer.append("</tr>");
+            writer.append("</thead>");
+            writer.append("<tbody>");
+
+            for (Record record : records) {
+                writer.append("<tr>");
+
+                for (int index = 0; index < fields.fields.length; index++) {
+                    writer.append("<td>");
+                    writer.append(ResultImpl.format0(record.getValue(index), false, true));
+                    writer.append("</td>");
+                }
+
+                writer.append("</tr>");
+            }
+
+            writer.append("</tbody>");
+            writer.append("</table>");
+        }
+        catch (java.io.IOException e) {
+            throw new IOException("Exception while writing HTML", e);
+        }
+    }
+
+}

--- a/jOOQ/src/main/java/org/jooq/impl/HtmlWriter.java
+++ b/jOOQ/src/main/java/org/jooq/impl/HtmlWriter.java
@@ -1,5 +1,6 @@
 package org.jooq.impl;
 
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.jooq.Field;
 import org.jooq.Record;
 import org.jooq.exception.IOException;
@@ -7,14 +8,14 @@ import org.jooq.exception.IOException;
 import java.io.Writer;
 import java.util.List;
 
-class HtmlWriter<R extends Record>  {
+class HtmlWriter<R extends Record> {
 
     HtmlWriter(Fields<R> fields, List<R> records) {
         this.fields = fields;
         this.records = records;
     }
 
-    private final Fields<R>   fields;
+    private final Fields<R> fields;
     private final List<R> records;
 
     final void formatHTML(Writer writer) {
@@ -25,7 +26,7 @@ class HtmlWriter<R extends Record>  {
 
             for (Field<?> field : fields.fields) {
                 writer.append("<th>");
-                writer.append(field.getName());
+                writer.append(StringEscapeUtils.escapeHtml4(field.getName()));
                 writer.append("</th>");
             }
 
@@ -38,7 +39,7 @@ class HtmlWriter<R extends Record>  {
 
                 for (int index = 0; index < fields.fields.length; index++) {
                     writer.append("<td>");
-                    writer.append(ResultImpl.format0(record.getValue(index), false, true));
+                    writer.append(StringEscapeUtils.escapeHtml4(ResultImpl.format0(record.getValue(index), false, true)));
                     writer.append("</td>");
                 }
 
@@ -47,8 +48,7 @@ class HtmlWriter<R extends Record>  {
 
             writer.append("</tbody>");
             writer.append("</table>");
-        }
-        catch (java.io.IOException e) {
+        } catch (java.io.IOException e) {
             throw new IOException("Exception while writing HTML", e);
         }
     }

--- a/jOOQ/src/main/java/org/jooq/impl/ResultImpl.java
+++ b/jOOQ/src/main/java/org/jooq/impl/ResultImpl.java
@@ -582,39 +582,7 @@ class ResultImpl<R extends Record> implements Result<R>, AttachableInternal {
 
     @Override
     public final void formatHTML(Writer writer) {
-        try {
-            writer.append("<table>");
-            writer.append("<thead>");
-            writer.append("<tr>");
-
-            for (Field<?> field : fields.fields) {
-                writer.append("<th>");
-                writer.append(field.getName());
-                writer.append("</th>");
-            }
-
-            writer.append("</tr>");
-            writer.append("</thead>");
-            writer.append("<tbody>");
-
-            for (Record record : this) {
-                writer.append("<tr>");
-
-                for (int index = 0; index < fields.fields.length; index++) {
-                    writer.append("<td>");
-                    writer.append(format0(record.getValue(index), false, true));
-                    writer.append("</td>");
-                }
-
-                writer.append("</tr>");
-            }
-
-            writer.append("</tbody>");
-            writer.append("</table>");
-        }
-        catch (java.io.IOException e) {
-            throw new IOException("Exception while writing HTML", e);
-        }
+        new HtmlWriter<R>(this.fields, this.records).formatHTML(writer);
     }
 
     @Override
@@ -728,7 +696,7 @@ class ResultImpl<R extends Record> implements Result<R>, AttachableInternal {
      * @param visual Whether the formatted output is to be consumed visually
      *            (HTML, TEXT) or by a machine (CSV, JSON, XML)
      */
-    private static final String format0(Object value, boolean changed, boolean visual) {
+    static final String format0(Object value, boolean changed, boolean visual) {
         String formatted = changed && visual ? "*" : "";
 
         if (value == null) {

--- a/jOOQ/src/test/java/org/jooq/impl/HtmlWriterTest.java
+++ b/jOOQ/src/test/java/org/jooq/impl/HtmlWriterTest.java
@@ -1,0 +1,69 @@
+package org.jooq.impl;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.test.AbstractTest;
+import org.junit.Test;
+
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tests HTML formatting
+ *
+ * @author Art O Cathain
+ */
+public class HtmlWriterTest extends AbstractTest {
+
+    private final Mockery context = new Mockery();
+    private final StringWriter writer = new StringWriter();
+
+    private HtmlWriter<Record> recordHtmlWriter;
+
+    @Test
+    public void testFormatNormal() {
+        setupExpectations("field1Name", "field1value1");
+
+        recordHtmlWriter.formatHTML(writer);
+
+        assertCorrectHtml("<table><thead><tr><th>field1Name</th></tr></thead><tbody><tr><td>field1value1</td></tr></tbody></table>");
+    }
+
+    @Test
+    public void testFormatWithXssAttempt() {
+        setupExpectations("field1Name", "<script>alert('xss')</script>");
+
+        recordHtmlWriter.formatHTML(writer);
+
+        assertCorrectHtml("<table><thead><tr><th>field1Name</th></tr></thead><tbody><tr><td>&lt;script&gt;alert('xss')&lt;/script&gt;</td></tr></tbody></table>");
+    }
+
+    private void setupExpectations(final String field1Name, final String field1value1) {
+        final Field field = context.mock(Field.class);
+        final Record record = context.mock(Record.class);
+        context.checking(
+                new Expectations() {{
+                    allowing(field).getName();
+
+                    will(returnValue(field1Name));
+
+                    allowing(record).getValue(0);
+                    will(returnValue(field1value1));
+
+                }});
+
+        Fields<Record> fields = new Fields<Record>(field);
+        List<Record> records = Collections.singletonList(record);
+
+        recordHtmlWriter = new HtmlWriter<Record>(fields, records);
+    }
+
+    private void assertCorrectHtml(String expected) {
+        assertEquals("HTML should be rendered correctly", expected, writer.toString());
+    }
+
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>org.jooq</groupId>
     <artifactId>jooq-parent</artifactId>
-    <version>3.6.2</version>
+    <version>3.6.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>jOOQ Parent</name>


### PR DESCRIPTION
Fix HTML injection

Used commons-lang3's `StringEscapeUtils` to escape field names and values in `ResultImpl.formatHTML`. Separated into another class to allow unit testing.