### PR TITLE
[#4554] Ensure batches are sent

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/BatchMultiple.java
+++ b/jOOQ/src/main/java/org/jooq/impl/BatchMultiple.java
@@ -75,6 +75,10 @@ class BatchMultiple implements Batch {
 
     @Override
     public final int[] execute() {
+        return execute(configuration, queries);
+    }
+
+    static int[] execute(final Configuration configuration, final Query[] queries) {
         ExecuteContext ctx = new DefaultExecuteContext(configuration, queries);
         ExecuteListener listener = new ExecuteListeners(ctx);
         Connection connection = ctx.connection();

--- a/jOOQ/src/main/java/org/jooq/impl/BatchSingle.java
+++ b/jOOQ/src/main/java/org/jooq/impl/BatchSingle.java
@@ -181,6 +181,12 @@ class BatchSingle implements BatchBindStep {
     }
 
     private final int[] executePrepared() {
+        // [#4554] If no variables are bound this should be treated like a
+        // BatchMultiple as the intention was most likely to call the varargs
+        // version of DSLContext#batch(Query... queries) with a single parameter.
+        if (allBindValues.isEmpty()) {
+            return BatchMultiple.execute(configuration, new Query[] { query });
+        }
         ExecuteContext ctx = new DefaultExecuteContext(configuration, new Query[] { query });
         ExecuteListener listener = new ExecuteListeners(ctx);
         Connection connection = ctx.connection();

--- a/jOOQ/src/test/java/org/jooq/test/MockTest.java
+++ b/jOOQ/src/test/java/org/jooq/test/MockTest.java
@@ -234,8 +234,8 @@ public class MockTest extends AbstractTest {
     }
 
     @Test
-    public void testBatchSingle() {
-        DSLContext e = DSL.using(new MockConnection(new BatchSingle()), SQLDialect.H2);
+    public void testBatchMultiple() {
+        DSLContext e = DSL.using(new MockConnection(new BatchMultiple()), SQLDialect.H2);
 
         int[] result =
         e.batch(
@@ -248,7 +248,7 @@ public class MockTest extends AbstractTest {
         assertEquals(1, result[1]);
     }
 
-    class BatchSingle implements MockDataProvider {
+    class BatchMultiple implements MockDataProvider {
 
         @Override
         public MockResult[] execute(MockExecuteContext ctx) throws SQLException {
@@ -268,8 +268,8 @@ public class MockTest extends AbstractTest {
     }
 
     @Test
-    public void testBatchMultiple() {
-        DSLContext e = DSL.using(new MockConnection(new BatchMultiple()), SQLDialect.H2);
+    public void testBatchSingle() {
+        DSLContext e = DSL.using(new MockConnection(new BatchSingle()), SQLDialect.H2);
 
         Query query = e.query("insert into x values(?, ?)", null, null);
 
@@ -284,7 +284,7 @@ public class MockTest extends AbstractTest {
         assertEquals(1, result[1]);
     }
 
-    class BatchMultiple implements MockDataProvider {
+    class BatchSingle implements MockDataProvider {
 
         @Override
         public MockResult[] execute(MockExecuteContext ctx) throws SQLException {


### PR DESCRIPTION
Due to overlap in the method prototypes of `DSLContext#batch(Query)` and
`DSLContext#batch(Query...)` calls intended to invoke the later with a
single argument actually invoke the former. To solve this we check if
`BatchBindStep#bind` was subsequently called and, if not, proceed as if
the var args version was called.