### PR TITLE
Do not escape dot in table names during code generation, but use capital case after it

### DIFF
--- a/jOOQ-codegen/src/main/java/org/jooq/util/GenerationUtil.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/util/GenerationUtil.java
@@ -178,19 +178,29 @@ class GenerationUtil {
             return "_";
         }
 
+        boolean uppercaseNext = false;
         for (int i = 0; i < literal.length(); i++) {
             char c = literal.charAt(i);
 
             if (!Character.isJavaIdentifierPart(c)) {
-                sb.append(escape(c));
+                if ('.' != c)
+                    sb.append(escape(c));
             }
             else if (i == 0 && !Character.isJavaIdentifierStart(literal.charAt(0))) {
                 sb.append("_");
                 sb.append(c);
             }
             else {
-                sb.append(c);
+                if (uppercaseNext)
+                    sb.append(Character.toUpperCase(c));
+                else
+                    sb.append(c);
             }
+
+            if ('.' == c)
+                uppercaseNext = true;
+            else
+                uppercaseNext = false;
         }
 
         return sb.toString();
@@ -205,7 +215,7 @@ class GenerationUtil {
     }
 
     private static String escape(char c) {
-        if (c == ' ' || c == '-')
+        if (c == ' ' || c == '-' || c == '.')
             return "_";
         else
             return "_" + Integer.toHexString(c);


### PR DESCRIPTION
In current version of jOOQ code generation table names like `user.users`, `user.achievements` are transformed to `User_2eusers`, `User_2eachievements` in class names (e.g. for tables, pojos and daos). 

Included patch changes this behaviour to: 
```user.users -> UserUsers```
```user.achievements -> UserAchievements```

i.e. dot is not included into the output, but instead next word is capitalized, producting nice pascal cased names.