### PR TITLE
Let SQLTable constructor pass SQL string to AbstractTable parent constructor

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/SQLTable.java
+++ b/jOOQ/src/main/java/org/jooq/impl/SQLTable.java
@@ -55,7 +55,7 @@ class SQLTable extends AbstractTable<Record> {
     private final QueryPart   delegate;
 
     public SQLTable(QueryPart delegate) {
-        super("table");
+        super(delegate.toString());
 
         this.delegate = delegate;
     }


### PR DESCRIPTION
…was as how SQLField does it taking value from delegate's toString(). 
It's not perfect, but at least it fixes the bug ("table" is not a good name) and it's consistent.