### PR TITLE
Code Quality fix - Printf-style format strings should not lead to unexpected behavior at runtime

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/AbstractRecord.java
+++ b/jOOQ/src/main/java/org/jooq/impl/AbstractRecord.java
@@ -1062,14 +1062,14 @@ abstract class AbstractRecord extends AbstractStore implements Record {
             throw new NullPointerException();
         }
         if (size() != that.size()) {
-            throw new ClassCastException(String.format("Trying to compare incomparable records (wrong degree):\n%s\n%s", this, that));
+            throw new ClassCastException(String.format("Trying to compare incomparable records (wrong degree):%n%s%n%s", this, that));
         }
 
         Class<?>[] thisTypes = this.fieldsRow().types();
         Class<?>[] thatTypes = that.fieldsRow().types();
 
         if (!asList(thisTypes).equals(asList(thatTypes))) {
-            throw new ClassCastException(String.format("Trying to compare incomparable records (type mismatch):\n%s\n%s", this, that));
+            throw new ClassCastException(String.format("Trying to compare incomparable records (type mismatch):%n%s%n%s", this, that));
         }
 
         for (int i = 0; i < size(); i++) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2275 - “Printf-style format strings should not lead to unexpected behaviour at runtime”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S2275?layout=true

Please let me know if you have any questions.

Javed.