### PR TITLE
Code Quality fix - Lazy initialization of "static" fields should be "synchronized

### DIFF
--- a/jOOQ-meta/src/main/java/org/jooq/util/postgres/PostgresDatabase.java
+++ b/jOOQ-meta/src/main/java/org/jooq/util/postgres/PostgresDatabase.java
@@ -659,7 +659,7 @@ public class PostgresDatabase extends AbstractDatabase {
         return DSL.using(getConnection(), SQLDialect.POSTGRES);
     }
 
-    private boolean is84() {
+    private synchronized boolean is84() {
         if (is84 == null) {
 
             // [#2916] Window functions were introduced with PostgreSQL 9.0
@@ -676,7 +676,7 @@ public class PostgresDatabase extends AbstractDatabase {
         return is84;
     }
 
-    private List<String> enumLabels(String nspname, String typname) {
+    private synchronized List<String> enumLabels(String nspname, String typname) {
         Field<Object> cast = field("{0}::{1}", PG_ENUM.ENUMLABEL, name(nspname, typname));
 
         if (canCastToEnumType == null) {

--- a/jOOQ-meta/src/main/java/org/jooq/util/postgres/PostgresRoutineDefinition.java
+++ b/jOOQ-meta/src/main/java/org/jooq/util/postgres/PostgresRoutineDefinition.java
@@ -150,7 +150,7 @@ public class PostgresRoutineDefinition extends AbstractRoutineDefinition {
         }
     }
 
-    private boolean is94() {
+    private synchronized boolean is94() {
         if (is94 == null) {
 
             // [#4254] INFORMATION_SCHEMA.PARAMETERS.PARAMETER_DEFAULT was added

--- a/jOOQ-meta/src/main/java/org/jooq/util/sqlite/SQLiteTableDefinition.java
+++ b/jOOQ-meta/src/main/java/org/jooq/util/sqlite/SQLiteTableDefinition.java
@@ -114,7 +114,7 @@ public class SQLiteTableDefinition extends AbstractTableDefinition {
         return result;
     }
 
-    private boolean existsSqliteSequence() {
+    private synchronized boolean existsSqliteSequence() {
         if (existsSqliteSequence == null) {
             existsSqliteSequence = create()
                 .selectCount()

--- a/jOOQ/src/main/java/org/jooq/impl/Utils.java
+++ b/jOOQ/src/main/java/org/jooq/impl/Utils.java
@@ -2156,7 +2156,7 @@ final class Utils {
     /**
      * Check if JPA classes can be loaded. This is only done once per JVM!
      */
-    private static final boolean isJPAAvailable() {
+    private synchronized static final boolean isJPAAvailable() {
         if (isJPAAvailable == null) {
             try {
                 Class.forName(Column.class.getName());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2444 - “Lazy initialization of "static" fields should be "synchronized”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S2444?layout=true

Please let me know if you have any questions.

Javed.