### PR TITLE
Generator extending JavaGenerator can override applied filters.

### DIFF
--- a/jOOQ-codegen/src/main/java/org/jooq/util/JavaGenerator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/util/JavaGenerator.java
@@ -199,7 +199,7 @@ public class JavaGenerator extends AbstractGenerator {
         this.catalogVersions = new LinkedHashMap<CatalogDefinition, String>();
 
         this.database = db;
-        this.database.addFilter(new AvoidAmbiguousClassesFilter());
+        applyDatabaseFilters(db);
         this.database.setIncludeRelations(generateRelations());
         this.database.setTableValuedFunctions(generateTableValuedFunctions());
 
@@ -437,6 +437,10 @@ public class JavaGenerator extends AbstractGenerator {
         // XXX [#651] Refactoring-cursor
         watch.splitInfo("Generation finished: " + schema.getQualifiedName());
         log.info("");
+    }
+
+    protected void applyDatabaseFilters(Database database) {
+        database.addFilter(new AvoidAmbiguousClassesFilter());
     }
 
     private class AvoidAmbiguousClassesFilter implements Database.Filter {


### PR DESCRIPTION
Adding `JavaGenerator.AvoidAmbiguousClassesFilter` to `Database` is hardcoded in `JavaGenerator.generate()` method. This prohibits generator strategy from intentionally generating the same names. I propose to move adding filter to overridable method.

For example, I have 2 tables `transactions` & `transactions_history` both having `state` enum column with the same definition - the columns represent the same thing. Custom generator strategy intentionally generates the same class name `TransactionState` for both columns.
