### PR TITLE
Use name for rendering field/table aliases

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/Alias.java
+++ b/jOOQ/src/main/java/org/jooq/impl/Alias.java
@@ -68,6 +68,7 @@ import static org.jooq.SQLDialect.SQLITE;
 import static org.jooq.impl.DSL.falseCondition;
 import static org.jooq.impl.DSL.field;
 import static org.jooq.impl.DSL.select;
+import static org.jooq.impl.DSL.name;
 import static org.jooq.impl.Utils.list;
 import static org.jooq.impl.Utils.DataKey.DATA_UNALIAS_ALIASES_IN_ORDER_BY;
 
@@ -196,7 +197,7 @@ class Alias<Q extends QueryPart> extends AbstractQueryPart {
             toSQLAs(context);
 
             context.sql(' ');
-            context.literal(alias);
+            context.visit(name(alias));
 
             // [#1801] Add field aliases to the table alias, if applicable
             if (fieldAliases != null && !emulatedDerivedColumnList) {
@@ -240,7 +241,7 @@ class Alias<Q extends QueryPart> extends AbstractQueryPart {
 
 
         else {
-            context.literal(alias);
+            context.visit(name(alias));
         }
     }
 


### PR DESCRIPTION
When a field name is modified by a VisitListener, the modified field name is ignored by aliases automatically generated by jOOQ, for example for a Oracle LIMIT query. 

See Testcase 1

```java
public class Testcase1 {

    private static class OracleVisitListener extends DefaultVisitListener {

        @Override
        public void visitStart(VisitContext context) {
            QueryPart queryPart = context.queryPart();

            if (queryPart instanceof Name) {
                String[] qualifiedName = ((Name) queryPart).getName();

                qualifiedName = Arrays.stream(qualifiedName).map(OracleVisitListener::getIdentifier).toArray(String[]::new);
                context.queryPart(name(qualifiedName));
            } 
        }

        private static String getIdentifier(String name) {
            String result = name.trim().toUpperCase();
            // replace all non alphanumeric characters.
            result = result.replaceAll("[^A-Z0-9_]+", "");

            if (result.length() > 30) {
                result = result.substring(0, 30);
            }

            return String.format("%s", result);
        }
    }

    public static void main(String[] args) throws SQLException {
        Connection connection = //.. oracle connection

        Configuration config = new DefaultConfiguration()
            .set(new DefaultConnectionProvider(connection))
            .set(SQLDialect.ORACLE11G)
            .set(() -> new OracleVisitListener());

        DSLContext context = DSL.using(config);

        String tableName = "aamy Test Table";
        String fieldName = "name field with spaces that exceeeds oracle length requirements";

        // drop if exists
        context.dropTableIfExists(tableName).execute();

        // create a table
        context.createTable(name(tableName))
            .column(fieldName, SQLDataType.VARCHAR).execute();

        // insert 50 rows
        InsertValuesStep1<Record, Object> insertQuery = context.insertInto(table(name(tableName)), field(name(fieldName)));

        IntStream.range(0, 51).forEach(i -> insertQuery.values("Row " + i));
        insertQuery.execute();

        // select from table, no problem
        context.select(field(name(fieldName), String.class))
            .from(table(name(tableName)))
            .fetch()
            .forEach(System.out::println);

        /*         
         select "NAMEFIELDWITHSPACESTHATEXCEEED" 
         from "AAMYTESTTABLE"                  
         */
                
        // select from table, with limit/window - exception
        context.select(field(name(fieldName), String.class))
            .from(table(name(tableName)))
            .limit(10)
            .fetch()
            .forEach(System.out::println);

        /*
         select "V0" "name field with spaces that exceeeds oracle length requirements" 
         from (
             select "X"."V0", rownum "rn" from (
                 select "NAMEFIELDWITHSPACESTHATEXCEEED" "v0" from "AAMYTESTTABLE") "X" 
                 where rownum <= (0 + 10)
             ) 
         where "RN" > 0            
         */
    }
```

This pull-request changes Alias to no longer use literal for rendering the actual alias, but name. This allows a VisitListener to modify the alias to match the actual field name. 
