### PR TITLE
Wrong implementation of internal SortFieldList.nulls()

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/SortFieldList.java
+++ b/jOOQ/src/main/java/org/jooq/impl/SortFieldList.java
@@ -95,7 +95,7 @@ class SortFieldList extends QueryPartList<SortField<?>> {
     final boolean nulls() {
         for (SortField<?> field : this)
             if (((SortFieldImpl<?>) field).getNullsFirst() ||
-                ((SortFieldImpl<?>) field).getNullsFirst())
+                ((SortFieldImpl<?>) field).getNullsLast())
                 return true;
 
         return false;


### PR DESCRIPTION
The subexpressions between `||` are equal. Looks like this should be `getNullsLast()`.