### PR TITLE
DefaultBindings for OffsetTime and OffsetDateTime handle negative offsets

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/DefaultBinding.java
+++ b/jOOQ/src/main/java/org/jooq/impl/DefaultBinding.java
@@ -1486,7 +1486,7 @@ public class DefaultBinding<T, U> implements Binding<T, U> {
             return null;
 
         // [#4338] PostgreSQL is more lenient regarding the offset format
-        if (string.lastIndexOf('+') == string.length() - 3)
+        if (string.lastIndexOf('+') == string.length() - 3 || string.lastIndexOf('-') == string.length() - 3)
             string = string + ":00";
 
         return OffsetTime.parse(string);
@@ -1497,7 +1497,7 @@ public class DefaultBinding<T, U> implements Binding<T, U> {
             return null;
 
         // [#4338] PostgreSQL is more lenient regarding the offset format
-        if (string.lastIndexOf('+') == string.length() - 3)
+        if (string.lastIndexOf('+') == string.length() - 3 || string.lastIndexOf('-') == string.length() - 3)
             string = string + ":00";
 
         // [#4338] SQL supports the alternative ISO 8601 date format, where a


### PR DESCRIPTION
[#4338] added support for converting PostgreSQL-formatted timestamps into OffsetDate's OffsetDateTime's, but did not correct for negative offsets.