### PR TITLE
MetaDataFieldProvider should not catch SQLFeatureNotSupportedException from ResultSetMetaData calls

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/MetaDataFieldProvider.java
+++ b/jOOQ/src/main/java/org/jooq/impl/MetaDataFieldProvider.java
@@ -46,7 +46,6 @@ import static org.jooq.impl.DSL.name;
 import java.io.Serializable;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
 
 import org.jooq.Configuration;
 import org.jooq.DataType;
@@ -116,7 +115,7 @@ final class MetaDataFieldProvider implements Serializable {
 
                     // [#4939] Some JDBC drivers such as Teradata and Cassandra don't implement
                     // ResultSetMetaData.getSchemaName and/or ResultSetMetaData.getTableName methods
-                    catch (SQLFeatureNotSupportedException e) {
+                    catch (SQLException e) {
                         name = name(columnLabel);
                     }
                 }


### PR DESCRIPTION
With Amazon Hive JDBC driver, `ResultSetMetaData.getSchemaName()` throws general `SQLException` rather than `SQLFeatureNotSupportedException`.

This is a followup of [pull request 4939](https://github.com/jOOQ/jOOQ/pull/4939).