### PR TITLE
Allow forced type definitions for PostgreSQL arrays

### DIFF
--- a/jOOQ-meta/src/main/java/org/jooq/util/AbstractDatabase.java
+++ b/jOOQ-meta/src/main/java/org/jooq/util/AbstractDatabase.java
@@ -1087,7 +1087,9 @@ public abstract class AbstractDatabase implements Database {
                      && (     definedType.getScale() != 0
                      ||   !p.matcher(definedType.getType() + "(" + definedType.getPrecision() + ")").matches())
                      && ( !p.matcher(definedType.getType() + "(" + definedType.getPrecision() + "," + definedType.getScale() + ")").matches() )
-                     && ( !p.matcher(definedType.getType() + "(" + definedType.getPrecision() + ", " + definedType.getScale() + ")").matches() )) {
+                     && ( !p.matcher(definedType.getType() + "(" + definedType.getPrecision() + ", " + definedType.getScale() + ")").matches() )
+                     && ( !isArrayType(definedType.getType())
+                     ||   !p.matcher(definedType.getType() + "[" + definedType.getUserType() + "]").matches() )) {
                     continue forcedTypeLoop;
                 }
             }


### PR DESCRIPTION
This will be a very useful addition to #4388. Not the best design, but other options I have in mind would require too big changes (e.g. extending DataTypeDefinition with a method to return full database-specific type representation).
