### PR TITLE
Accept column default expressions using sequences as identity columns in H2

### DIFF
--- a/jOOQ-meta/src/main/java/org/jooq/util/h2/H2TableDefinition.java
+++ b/jOOQ-meta/src/main/java/org/jooq/util/h2/H2TableDefinition.java
@@ -41,6 +41,7 @@
 package org.jooq.util.h2;
 
 import static org.jooq.util.h2.information_schema.tables.Columns.COLUMNS;
+import static org.jooq.tools.StringUtils.defaultString;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -103,7 +104,8 @@ public class H2TableDefinition extends AbstractTableDefinition {
                 record.get(Columns.COLUMN_NAME),
                 record.get(Columns.ORDINAL_POSITION),
                 type,
-                null != record.get(Columns.SEQUENCE_NAME),
+                null != record.get(Columns.SEQUENCE_NAME)
+		    || defaultString(record.get(COLUMNS.COLUMN_DEFAULT)).startsWith("NEXTVAL"),
                 record.get(Columns.REMARKS));
 
             result.add(column);


### PR DESCRIPTION
The H2TableDefinition.java currently only detects IDENTITY columns based on a non-null SEQUENCE_NAME in the column's INFORMATION_SCHEMA. 
In the database I have to deal with, there are composite primary keys defined like this:

```sql
CREATE TABLE foo (
  id        BIGINT       NOT NULL               DEFAULT nextval('uid_seq'),
  tenant_id BIGINT       NOT NULL,
...
  CONSTRAINT pk_user PRIMARY KEY (id, tenant_id))
```

for both Postgres and H2. In Postgres, inserts work as expected (due to the 'returning' clause for the keys), but nor for H2: After `insert into "PUBLIC"."FOO" ("TENANT_ID", ...) values (1, ...)`, no generated key for the id column is returned. In fact, the INFORMATION_SCHEMA does not contain a SEQUENCE_NAME
This patch resolves that, as it adds an alternative condition to detect an identity column (that is also used in PostgresTableDefinition).  