### PR TITLE
Correct signature of Record.map()

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/AbstractRecord.java
+++ b/jOOQ/src/main/java/org/jooq/impl/AbstractRecord.java
@@ -761,7 +761,7 @@ abstract class AbstractRecord extends AbstractStore implements Record {
     }
 
     @Override
-    public final <E> E map(RecordMapper<Record, E> mapper) {
+    public final <E> E map(RecordMapper<? extends Record, E> mapper) {
         return mapper.map(this);
     }
 


### PR DESCRIPTION
It should be possible to map using mappers of specific types of sub-record

Unfortunately Java does not support type covariance in this way by default

So probably <? extends Record> is the correct type of mapper