### PR TITLE
treat column default expressions using RANDOM_UUID() as identity colu…

### DIFF
--- a/jOOQ-meta/src/main/java/org/jooq/util/h2/H2TableDefinition.java
+++ b/jOOQ-meta/src/main/java/org/jooq/util/h2/H2TableDefinition.java
@@ -109,7 +109,9 @@ public class H2TableDefinition extends AbstractTableDefinition {
                 null != record.get(Columns.SEQUENCE_NAME)
 
                 // [#5331] DEFAULT nextval('sequence') (PostgreSQL style)
-             || defaultString(record.get(Columns.COLUMN_DEFAULT)).trim().toLowerCase().startsWith("nextval"),
+             || defaultString(record.get(Columns.COLUMN_DEFAULT)).trim().toLowerCase().startsWith("nextval")
+                // [#5331] DEFAULT RANDOM_UUID()
+             || defaultString(record.get(Columns.COLUMN_DEFAULT)).trim().toLowerCase().equals("random_uuid()"),
                 record.get(Columns.REMARKS));
 
             result.add(column);


### PR DESCRIPTION
…mns in H2

The fix in #5331 is incomplete as columns defaulting to RANDOM_UUID() should also be treated as identity columns
