### PR TITLE
Fix partitioning of window function

### DIFF
--- a/jOOQ-examples/jOOQ-spark-chart-example/src/main/java/org/jooq/example/chart/SakilaReportService.java
+++ b/jOOQ-examples/jOOQ-spark-chart-example/src/main/java/org/jooq/example/chart/SakilaReportService.java
@@ -139,7 +139,7 @@ public class SakilaReportService {
             .select(
                 STORE.STORE_ID,
                 PAYMENT.PAYMENT_DATE.cast(DATE).as(PAYMENT.PAYMENT_DATE),
-                sum(sum(PAYMENT.AMOUNT)).over(orderBy(PAYMENT.PAYMENT_DATE.cast(DATE))).as(PAYMENT.AMOUNT)
+                sum(sum(PAYMENT.AMOUNT)).over(partitionBy(STORE.STORE_ID).orderBy(PAYMENT.PAYMENT_DATE.cast(DATE))).as(PAYMENT.AMOUNT)
             )
             .from(STORE)
             .join(INVENTORY).using(INVENTORY.STORE_ID)


### PR DESCRIPTION
The sum of the earnings was calculated wrong, each store in the result had the sum over both stores, which is not what the graph suggests to me. The graph shows the cumulative earnings, whereas the query must compute earnings per store.