### PR TITLE
Applied skeletal implementation to interface migration automated refactoring

### DIFF
--- a/jOOQ-codegen/src/main/java/org/jooq/util/AbstractGenerator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/util/AbstractGenerator.java
@@ -472,18 +472,6 @@ abstract class AbstractGenerator implements Generator {
     }
 
     @Override
-    @Deprecated
-    public String fullyQualifiedTypes() {
-        return generateFullyQualifiedTypes();
-    }
-
-    @Override
-    @Deprecated
-    public void setFullyQualifiedTypes(String fullyQualifiedTypes) {
-        setGenerateFullyQualifiedTypes(fullyQualifiedTypes);
-    }
-
-    @Override
     public String generateFullyQualifiedTypes() {
         return generateFullyQualifiedTypes;
     }

--- a/jOOQ-codegen/src/main/java/org/jooq/util/Generator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/util/Generator.java
@@ -365,7 +365,10 @@ public interface Generator {
      * @deprecated - Use {@link #generateFullyQualifiedTypes()} instead.
      */
     @Deprecated
-    String fullyQualifiedTypes();
+	default
+    String fullyQualifiedTypes() {
+	    return generateFullyQualifiedTypes();
+	}
 
     /**
      * A regular expression matching all the types in generated code that should
@@ -375,7 +378,10 @@ public interface Generator {
      *             instead.
      */
     @Deprecated
-    void setFullyQualifiedTypes(String fullyQualifiedTypes);
+	default
+    void setFullyQualifiedTypes(String fullyQualifiedTypes) {
+	    setGenerateFullyQualifiedTypes(fullyQualifiedTypes);
+	}
 
     /**
      * A regular expression matching all the types in generated code that should

--- a/jOOQ-codegen/src/main/java/org/jooq/util/Generator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/util/Generator.java
@@ -365,10 +365,9 @@ public interface Generator {
      * @deprecated - Use {@link #generateFullyQualifiedTypes()} instead.
      */
     @Deprecated
-	default
-    String fullyQualifiedTypes() {
-	    return generateFullyQualifiedTypes();
-	}
+    default String fullyQualifiedTypes() {
+        return generateFullyQualifiedTypes();
+    }
 
     /**
      * A regular expression matching all the types in generated code that should
@@ -378,10 +377,9 @@ public interface Generator {
      *             instead.
      */
     @Deprecated
-	default
-    void setFullyQualifiedTypes(String fullyQualifiedTypes) {
-	    setGenerateFullyQualifiedTypes(fullyQualifiedTypes);
-	}
+    default void setFullyQualifiedTypes(String fullyQualifiedTypes) {
+        setGenerateFullyQualifiedTypes(fullyQualifiedTypes);
+    }
 
     /**
      * A regular expression matching all the types in generated code that should

--- a/jOOQ-meta/src/main/java/org/jooq/util/AbstractDefinition.java
+++ b/jOOQ-meta/src/main/java/org/jooq/util/AbstractDefinition.java
@@ -90,11 +90,6 @@ public abstract class AbstractDefinition implements Definition {
     }
 
     @Override
-    public /* non-final */ CatalogDefinition getCatalog() {
-        return getSchema().getCatalog();
-    }
-
-    @Override
     public final SchemaDefinition getSchema() {
         return schema;
     }
@@ -107,16 +102,6 @@ public abstract class AbstractDefinition implements Definition {
     @Override
     public final String getInputName() {
         return name;
-    }
-
-    /**
-     * Subclasses may override this method
-     *
-     * {@inheritDoc}
-     */
-    @Override
-    public String getOutputName() {
-        return getInputName();
     }
 
     @Override

--- a/jOOQ-meta/src/main/java/org/jooq/util/AbstractPackageDefinition.java
+++ b/jOOQ-meta/src/main/java/org/jooq/util/AbstractPackageDefinition.java
@@ -61,16 +61,6 @@ public abstract class AbstractPackageDefinition extends AbstractDefinition imple
     }
 
     @Override
-    public List<Definition> getDefinitionPath() {
-        List<Definition> result = new ArrayList<Definition>();
-
-        result.addAll(getSchema().getDefinitionPath());
-        result.add(this);
-
-        return result;
-    }
-
-    @Override
     public final List<RoutineDefinition> getRoutines() {
         if (routines == null) {
             routines = new ArrayList<RoutineDefinition>();

--- a/jOOQ-meta/src/main/java/org/jooq/util/AbstractRoutineDefinition.java
+++ b/jOOQ-meta/src/main/java/org/jooq/util/AbstractRoutineDefinition.java
@@ -164,11 +164,6 @@ public abstract class AbstractRoutineDefinition extends AbstractDefinition imple
     }
 
     @Override
-    public /* non-final */ boolean isSQLUsable() {
-        return getReturnValue() != null && getOutParameters().isEmpty();
-    }
-
-    @Override
     public final boolean isAggregate() {
         return aggregate;
     }

--- a/jOOQ-meta/src/main/java/org/jooq/util/AbstractTableDefinition.java
+++ b/jOOQ-meta/src/main/java/org/jooq/util/AbstractTableDefinition.java
@@ -163,11 +163,6 @@ implements TableDefinition {
     }
 
     @Override
-    public /* non-final */ boolean isTableValuedFunction() {
-        return false;
-    }
-
-    @Override
     protected List<ColumnDefinition> getElements0() throws SQLException {
         return null;
     }

--- a/jOOQ-meta/src/main/java/org/jooq/util/AbstractUDTDefinition.java
+++ b/jOOQ-meta/src/main/java/org/jooq/util/AbstractUDTDefinition.java
@@ -40,7 +40,6 @@
  */
 package org.jooq.util;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -85,9 +84,4 @@ implements
     }
 
     protected abstract List<RoutineDefinition> getRoutines0();
-
-    @Override
-    public List<AttributeDefinition> getConstants() {
-        return Collections.emptyList();
-    }
 }

--- a/jOOQ-meta/src/main/java/org/jooq/util/Definition.java
+++ b/jOOQ-meta/src/main/java/org/jooq/util/Definition.java
@@ -41,6 +41,7 @@
 
 package org.jooq.util;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -59,7 +60,9 @@ public interface Definition {
     /**
      * @return The catalog of this object.
      */
-    CatalogDefinition getCatalog();
+    default CatalogDefinition getCatalog() {
+	    return getSchema().getCatalog();
+	}
 
     /**
      * @return The schema of this object or <code>null</code> if this object is
@@ -84,7 +87,9 @@ public interface Definition {
      *         target database. This may differ from the input name if schema /
      *         table rewriting is applied.
      */
-    String getOutputName();
+    default String getOutputName() {
+	    return getInputName();
+	}
 
     /**
      * @return The comment of this object
@@ -95,7 +100,14 @@ public interface Definition {
      * @return A path of definitions for this definition, e.g.
      *         <code>[schema].[package].[routine].[parameter]</code>
      */
-    List<Definition> getDefinitionPath();
+    default List<Definition> getDefinitionPath() {
+	    List<Definition> result = new ArrayList<Definition>();
+	
+	    result.addAll(getSchema().getDefinitionPath());
+	    result.add(this);
+	
+	    return result;
+	}
 
     /**
      * @return A qualified name for this object (corresponding to

--- a/jOOQ-meta/src/main/java/org/jooq/util/Definition.java
+++ b/jOOQ-meta/src/main/java/org/jooq/util/Definition.java
@@ -61,8 +61,8 @@ public interface Definition {
      * @return The catalog of this object.
      */
     default CatalogDefinition getCatalog() {
-	    return getSchema().getCatalog();
-	}
+        return getSchema().getCatalog();
+    }
 
     /**
      * @return The schema of this object or <code>null</code> if this object is
@@ -89,8 +89,8 @@ public interface Definition {
      *         table rewriting is applied.
      */
     default String getOutputName() {
-	    return getInputName();
-	}
+        return getInputName();
+    }
 
     /**
      * @return The comment of this object
@@ -102,13 +102,13 @@ public interface Definition {
      *         <code>[schema].[package].[routine].[parameter]</code>
      */
     default List<Definition> getDefinitionPath() {
-	    List<Definition> result = new ArrayList<Definition>();
-	
-	    result.addAll(getSchema().getDefinitionPath());
-	    result.add(this);
-	
-	    return result;
-	}
+        List<Definition> result = new ArrayList<Definition>();
+    
+        result.addAll(getSchema().getDefinitionPath());
+        result.add(this);
+    
+        return result;
+    }
 
     /**
      * @return A qualified name for this object (corresponding to

--- a/jOOQ-meta/src/main/java/org/jooq/util/Definition.java
+++ b/jOOQ-meta/src/main/java/org/jooq/util/Definition.java
@@ -83,6 +83,7 @@ public interface Definition {
     String getInputName();
 
     /**
+     * Subclasses may override the default implementation of this method
      * @return The name of this object, e.g. [my_table], as defined for the
      *         target database. This may differ from the input name if schema /
      *         table rewriting is applied.

--- a/jOOQ-meta/src/main/java/org/jooq/util/PackageDefinition.java
+++ b/jOOQ-meta/src/main/java/org/jooq/util/PackageDefinition.java
@@ -59,6 +59,6 @@ public interface PackageDefinition extends Definition {
      * Fetch all constants from the package.
      */
     default List<AttributeDefinition> getConstants() {
-	    return Collections.emptyList();
-	}
+        return Collections.emptyList();
+    }
 }

--- a/jOOQ-meta/src/main/java/org/jooq/util/PackageDefinition.java
+++ b/jOOQ-meta/src/main/java/org/jooq/util/PackageDefinition.java
@@ -40,6 +40,7 @@
  */
 package org.jooq.util;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -57,5 +58,7 @@ public interface PackageDefinition extends Definition {
     /**
      * Fetch all constants from the package.
      */
-    List<AttributeDefinition> getConstants();
+    default List<AttributeDefinition> getConstants() {
+	    return Collections.emptyList();
+	}
 }

--- a/jOOQ-meta/src/main/java/org/jooq/util/RoutineDefinition.java
+++ b/jOOQ-meta/src/main/java/org/jooq/util/RoutineDefinition.java
@@ -86,8 +86,8 @@ public interface RoutineDefinition extends Definition {
      *         parameters)
      */
     default boolean isSQLUsable() {
-	    return getReturnValue() != null && getOutParameters().isEmpty();
-	}
+        return getReturnValue() != null && getOutParameters().isEmpty();
+    }
 
     /**
      * @return Whether this routine is an aggregate function

--- a/jOOQ-meta/src/main/java/org/jooq/util/RoutineDefinition.java
+++ b/jOOQ-meta/src/main/java/org/jooq/util/RoutineDefinition.java
@@ -85,7 +85,9 @@ public interface RoutineDefinition extends Definition {
      * @return Whether this routine can be used in SQL (a function without OUT
      *         parameters)
      */
-    boolean isSQLUsable();
+    default boolean isSQLUsable() {
+	    return getReturnValue() != null && getOutParameters().isEmpty();
+	}
 
     /**
      * @return Whether this routine is an aggregate function

--- a/jOOQ-meta/src/main/java/org/jooq/util/TableDefinition.java
+++ b/jOOQ-meta/src/main/java/org/jooq/util/TableDefinition.java
@@ -122,6 +122,8 @@ public interface TableDefinition extends Definition {
     /**
      * Whether this table is a table-valued function.
      */
-    boolean isTableValuedFunction();
+    default boolean isTableValuedFunction() {
+	    return false;
+	}
 
 }

--- a/jOOQ-meta/src/main/java/org/jooq/util/TableDefinition.java
+++ b/jOOQ-meta/src/main/java/org/jooq/util/TableDefinition.java
@@ -123,7 +123,7 @@ public interface TableDefinition extends Definition {
      * Whether this table is a table-valued function.
      */
     default boolean isTableValuedFunction() {
-	    return false;
-	}
+        return false;
+    }
 
 }

--- a/jOOQ/src/main/java/org/jooq/DAO.java
+++ b/jOOQ/src/main/java/org/jooq/DAO.java
@@ -92,7 +92,9 @@ public interface DAO<R extends TableRecord<R>, P, T> {
      * This method is a convenient way of accessing
      * <code>configuration().dialect().family()</code>.
      */
-    SQLDialect family();
+    default SQLDialect family() {
+	    return dialect().family();
+	}
 
     /**
      * Expose the {@link RecordMapper} that is used internally by this

--- a/jOOQ/src/main/java/org/jooq/DAO.java
+++ b/jOOQ/src/main/java/org/jooq/DAO.java
@@ -93,8 +93,8 @@ public interface DAO<R extends TableRecord<R>, P, T> {
      * <code>configuration().dialect().family()</code>.
      */
     default SQLDialect family() {
-	    return dialect().family();
-	}
+        return dialect().family();
+    }
 
     /**
      * Expose the {@link RecordMapper} that is used internally by this

--- a/jOOQ/src/main/java/org/jooq/Query.java
+++ b/jOOQ/src/main/java/org/jooq/Query.java
@@ -127,7 +127,9 @@ public interface Query extends QueryPart, Attachable , AutoCloseable  {
      * Calling {@link #execute()} on such queries has no effect, but beware that
      * {@link #getSQL()} may not render valid SQL!
      */
-    boolean isExecutable();
+    default boolean isExecutable() {
+	    return true;
+	}
 
     /**
      * Retrieve the SQL code rendered by this Query.

--- a/jOOQ/src/main/java/org/jooq/Query.java
+++ b/jOOQ/src/main/java/org/jooq/Query.java
@@ -126,6 +126,8 @@ public interface Query extends QueryPart, Attachable , AutoCloseable  {
      * DML queries may be incomplete in structure and thus not executable.
      * Calling {@link #execute()} on such queries has no effect, but beware that
      * {@link #getSQL()} may not render valid SQL!
+     * <p>
+     * Subclasses may override the default implementation of this method.
      */
     default boolean isExecutable() {
 	    return true;

--- a/jOOQ/src/main/java/org/jooq/Query.java
+++ b/jOOQ/src/main/java/org/jooq/Query.java
@@ -130,8 +130,8 @@ public interface Query extends QueryPart, Attachable , AutoCloseable  {
      * Subclasses may override the default implementation of this method.
      */
     default boolean isExecutable() {
-	    return true;
-	}
+        return true;
+    }
 
     /**
      * Retrieve the SQL code rendered by this Query.

--- a/jOOQ/src/main/java/org/jooq/QueryPartInternal.java
+++ b/jOOQ/src/main/java/org/jooq/QueryPartInternal.java
@@ -114,6 +114,8 @@ public interface QueryPartInternal extends QueryPart {
      * clause should be rendered.
      * <p>
      * This method is for JOOQ INTERNAL USE only. Do not reference directly
+     * <p>
+     * Subclasses may override the default implementation.
      */
     default boolean declaresFields() {
 	    return false;
@@ -127,6 +129,8 @@ public interface QueryPartInternal extends QueryPart {
      * clause should be rendered.
      * <p>
      * This method is for JOOQ INTERNAL USE only. Do not reference directly
+     * <p>
+     * Subclasses may override the default implementation.
      */
     default boolean declaresTables() {
 	    return false;
@@ -140,6 +144,8 @@ public interface QueryPartInternal extends QueryPart {
      * clause should be rendered.
      * <p>
      * This method is for JOOQ INTERNAL USE only. Do not reference directly
+     * <p>
+     * Subclasses may override the default implementation.
      */
     default boolean declaresWindows() {
 	    return false;
@@ -153,6 +159,8 @@ public interface QueryPartInternal extends QueryPart {
      * clause should be rendered.
      * <p>
      * This method is for JOOQ INTERNAL USE only. Do not reference directly
+     * <p>
+     * Subclasses may override the default implementation.
      */
     default boolean declaresCTE() {
 	    return false;
@@ -166,6 +174,8 @@ public interface QueryPartInternal extends QueryPart {
      * clause should be rendered.
      * <p>
      * This method is for JOOQ INTERNAL USE only. Do not reference directly
+     * <p>
+     * Subclasses may override the default implementation.
      */
     default boolean generatesCast() {
 	    return false;

--- a/jOOQ/src/main/java/org/jooq/QueryPartInternal.java
+++ b/jOOQ/src/main/java/org/jooq/QueryPartInternal.java
@@ -115,7 +115,9 @@ public interface QueryPartInternal extends QueryPart {
      * <p>
      * This method is for JOOQ INTERNAL USE only. Do not reference directly
      */
-    boolean declaresFields();
+    default boolean declaresFields() {
+	    return false;
+	}
 
     /**
      * Check whether this {@link QueryPart} is able to declare tables in a
@@ -126,7 +128,9 @@ public interface QueryPartInternal extends QueryPart {
      * <p>
      * This method is for JOOQ INTERNAL USE only. Do not reference directly
      */
-    boolean declaresTables();
+    default boolean declaresTables() {
+	    return false;
+	}
 
     /**
      * Check whether this {@link QueryPart} is able to declare windows in a
@@ -137,7 +141,9 @@ public interface QueryPartInternal extends QueryPart {
      * <p>
      * This method is for JOOQ INTERNAL USE only. Do not reference directly
      */
-    boolean declaresWindows();
+    default boolean declaresWindows() {
+	    return false;
+	}
 
     /**
      * Check whether this {@link QueryPart} is able to declare common table
@@ -148,7 +154,9 @@ public interface QueryPartInternal extends QueryPart {
      * <p>
      * This method is for JOOQ INTERNAL USE only. Do not reference directly
      */
-    boolean declaresCTE();
+    default boolean declaresCTE() {
+	    return false;
+	}
 
     /**
      * Check whether this {@link QueryPart} is able to generate
@@ -159,5 +167,7 @@ public interface QueryPartInternal extends QueryPart {
      * <p>
      * This method is for JOOQ INTERNAL USE only. Do not reference directly
      */
-    boolean generatesCast();
+    default boolean generatesCast() {
+	    return false;
+	}
 }

--- a/jOOQ/src/main/java/org/jooq/QueryPartInternal.java
+++ b/jOOQ/src/main/java/org/jooq/QueryPartInternal.java
@@ -118,8 +118,8 @@ public interface QueryPartInternal extends QueryPart {
      * Subclasses may override the default implementation.
      */
     default boolean declaresFields() {
-	    return false;
-	}
+        return false;
+    }
 
     /**
      * Check whether this {@link QueryPart} is able to declare tables in a
@@ -133,8 +133,8 @@ public interface QueryPartInternal extends QueryPart {
      * Subclasses may override the default implementation.
      */
     default boolean declaresTables() {
-	    return false;
-	}
+        return false;
+    }
 
     /**
      * Check whether this {@link QueryPart} is able to declare windows in a
@@ -148,8 +148,8 @@ public interface QueryPartInternal extends QueryPart {
      * Subclasses may override the default implementation.
      */
     default boolean declaresWindows() {
-	    return false;
-	}
+        return false;
+    }
 
     /**
      * Check whether this {@link QueryPart} is able to declare common table
@@ -163,8 +163,8 @@ public interface QueryPartInternal extends QueryPart {
      * Subclasses may override the default implementation.
      */
     default boolean declaresCTE() {
-	    return false;
-	}
+        return false;
+    }
 
     /**
      * Check whether this {@link QueryPart} is able to generate
@@ -178,6 +178,6 @@ public interface QueryPartInternal extends QueryPart {
      * Subclasses may override the default implementation.
      */
     default boolean generatesCast() {
-	    return false;
-	}
+        return false;
+    }
 }

--- a/jOOQ/src/main/java/org/jooq/ResultQuery.java
+++ b/jOOQ/src/main/java/org/jooq/ResultQuery.java
@@ -3171,8 +3171,8 @@ public interface ResultQuery<R extends Record> extends Query, Iterable<R> {
      * Subclasses may override the default implementation of this method
      */
     default Class<? extends R> getRecordType() {
-	    return null;
-	}
+        return null;
+    }
 
     /**
      * {@inheritDoc}

--- a/jOOQ/src/main/java/org/jooq/ResultQuery.java
+++ b/jOOQ/src/main/java/org/jooq/ResultQuery.java
@@ -3167,6 +3167,8 @@ public interface ResultQuery<R extends Record> extends Query, Iterable<R> {
 
     /**
      * The record type produced by this query.
+     * <p>
+     * Subclasses may override the default implementation of this method
      */
     default Class<? extends R> getRecordType() {
 	    return null;

--- a/jOOQ/src/main/java/org/jooq/ResultQuery.java
+++ b/jOOQ/src/main/java/org/jooq/ResultQuery.java
@@ -3168,7 +3168,9 @@ public interface ResultQuery<R extends Record> extends Query, Iterable<R> {
     /**
      * The record type produced by this query.
      */
-    Class<? extends R> getRecordType();
+    default Class<? extends R> getRecordType() {
+	    return null;
+	}
 
     /**
      * {@inheritDoc}

--- a/jOOQ/src/main/java/org/jooq/Table.java
+++ b/jOOQ/src/main/java/org/jooq/Table.java
@@ -66,6 +66,7 @@ import static org.jooq.SQLDialect.SQLITE;
 
 import java.sql.Timestamp;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.jooq.conf.Settings;
@@ -146,14 +147,18 @@ public interface Table<R extends Record> extends TableLike<R> {
      * @return The table's <code>IDENTITY</code> information, or
      *         <code>null</code>, if no such information is available.
      */
-    Identity<R, ?> getIdentity();
+    default Identity<R, ?> getIdentity() {
+	    return null;
+	}
     /**
      * Retrieve the table's primary key
      *
      * @return The primary key. This is never <code>null</code> for an updatable
      *         table.
      */
-    UniqueKey<R> getPrimaryKey();
+    default UniqueKey<R> getPrimaryKey() {
+	    return null;
+	}
 
     /**
      * A "version" field holding record version information used for optimistic
@@ -212,7 +217,9 @@ public interface Table<R extends Record> extends TableLike<R> {
      *         for a {@link Table} with a {@link Table#getPrimaryKey()}. This
      *         method returns an unmodifiable list.
      */
-    List<UniqueKey<R>> getKeys();
+    default List<UniqueKey<R>> getKeys() {
+	    return Collections.emptyList();
+	}
 
     /**
      * Get a list of <code>FOREIGN KEY</code>'s of a specific table, referencing
@@ -232,7 +239,9 @@ public interface Table<R extends Record> extends TableLike<R> {
      * @return This table's <code>FOREIGN KEY</code>'s. This is never
      *         <code>null</code>.
      */
-    List<ForeignKey<R, ?>> getReferences();
+    default List<ForeignKey<R, ?>> getReferences() {
+	    return Collections.emptyList();
+	}
 
     /**
      * Get a list of <code>FOREIGN KEY</code>'s of this table, referencing a

--- a/jOOQ/src/main/java/org/jooq/Table.java
+++ b/jOOQ/src/main/java/org/jooq/Table.java
@@ -150,8 +150,8 @@ public interface Table<R extends Record> extends TableLike<R> {
      *         <code>null</code>, if no such information is available.
      */
     default Identity<R, ?> getIdentity() {
-	    return null;
-	}
+        return null;
+    }
     /**
      * Retrieve the table's primary key
      * <p>
@@ -161,8 +161,8 @@ public interface Table<R extends Record> extends TableLike<R> {
      *         table.
      */
     default UniqueKey<R> getPrimaryKey() {
-	    return null;
-	}
+        return null;
+    }
 
     /**
      * A "version" field holding record version information used for optimistic
@@ -224,8 +224,8 @@ public interface Table<R extends Record> extends TableLike<R> {
      *         method returns an unmodifiable list.
      */
     default List<UniqueKey<R>> getKeys() {
-	    return Collections.emptyList();
-	}
+        return Collections.emptyList();
+    }
 
     /**
      * Get a list of <code>FOREIGN KEY</code>'s of a specific table, referencing
@@ -248,8 +248,8 @@ public interface Table<R extends Record> extends TableLike<R> {
      *         <code>null</code>.
      */
     default List<ForeignKey<R, ?>> getReferences() {
-	    return Collections.emptyList();
-	}
+        return Collections.emptyList();
+    }
 
     /**
      * Get a list of <code>FOREIGN KEY</code>'s of this table, referencing a

--- a/jOOQ/src/main/java/org/jooq/Table.java
+++ b/jOOQ/src/main/java/org/jooq/Table.java
@@ -143,6 +143,8 @@ public interface Table<R extends Record> extends TableLike<R> {
      * <p>
      * Note: Unfortunately, this is not supported in the Oracle dialect, where
      * identities emulated by triggers cannot be formally detected.
+     * <p>
+     * Subclasses should override the default implementation of this method
      *
      * @return The table's <code>IDENTITY</code> information, or
      *         <code>null</code>, if no such information is available.
@@ -152,6 +154,8 @@ public interface Table<R extends Record> extends TableLike<R> {
 	}
     /**
      * Retrieve the table's primary key
+     * <p>
+     * Subclasses may override the default implementation of this method
      *
      * @return The primary key. This is never <code>null</code> for an updatable
      *         table.
@@ -212,6 +216,8 @@ public interface Table<R extends Record> extends TableLike<R> {
 
     /**
      * Retrieve all of the table's unique keys.
+     * <p>
+     * Subclasses should override the default implementation of this method
      *
      * @return All keys. This is never <code>null</code>. This is never empty
      *         for a {@link Table} with a {@link Table#getPrimaryKey()}. This
@@ -235,6 +241,8 @@ public interface Table<R extends Record> extends TableLike<R> {
 
     /**
      * Get the list of <code>FOREIGN KEY</code>'s of this table
+     * <p>
+     * Subclasses should override the default implementation of this method
      *
      * @return This table's <code>FOREIGN KEY</code>'s. This is never
      *         <code>null</code>.

--- a/jOOQ/src/main/java/org/jooq/impl/AbstractQuery.java
+++ b/jOOQ/src/main/java/org/jooq/impl/AbstractQuery.java
@@ -444,15 +444,6 @@ abstract class AbstractQuery extends AbstractQueryPart implements Query, Attacha
         }
     }
 
-    /**
-     * Default implementation for executable check. Subclasses may override this
-     * method.
-     */
-    @Override
-    public boolean isExecutable() {
-        return true;
-    }
-
     static class Rendered {
         String                  sql;
         QueryPartList<Param<?>> bindValues;

--- a/jOOQ/src/main/java/org/jooq/impl/AbstractQueryPart.java
+++ b/jOOQ/src/main/java/org/jooq/impl/AbstractQueryPart.java
@@ -93,45 +93,7 @@ abstract class AbstractQueryPart implements QueryPartInternal {
     // The QueryPart and QueryPart internal API
     // -------------------------------------------------------------------------
 
-    /**
-     * Subclasses may override this
-     */
-    @Override
-    public boolean declaresFields() {
-        return false;
-    }
-
-    /**
-     * Subclasses may override this
-     */
-    @Override
-    public boolean declaresTables() {
-        return false;
-    }
-
-    /**
-     * Subclasses may override this
-     */
-    @Override
-    public boolean declaresWindows() {
-        return false;
-    }
-
-    /**
-     * Subclasses may override this
-     */
-    @Override
-    public boolean declaresCTE() {
-        return false;
-    }
-
-    /**
-     * Subclasses may override this
-     */
-    @Override
-    public boolean generatesCast() {
-        return false;
-    }
+    
 
     // -------------------------------------------------------------------------
     // The Object API

--- a/jOOQ/src/main/java/org/jooq/impl/AbstractResultQuery.java
+++ b/jOOQ/src/main/java/org/jooq/impl/AbstractResultQuery.java
@@ -1252,16 +1252,6 @@ abstract class AbstractResultQuery<R extends Record> extends AbstractQuery imple
         return fetch().intoSet(field, converter);
     }
 
-    /**
-     * Subclasses may override this method
-     * <p>
-     * {@inheritDoc}
-     */
-    @Override
-    public Class<? extends R> getRecordType() {
-        return null;
-    }
-
     @Override
     public final <T> List<T> fetchInto(Class<? extends T> type) {
         return fetch().into(type);

--- a/jOOQ/src/main/java/org/jooq/impl/AbstractTable.java
+++ b/jOOQ/src/main/java/org/jooq/impl/AbstractTable.java
@@ -76,7 +76,6 @@ import org.jooq.DataType;
 import org.jooq.DivideByOnStep;
 import org.jooq.Field;
 import org.jooq.ForeignKey;
-import org.jooq.Identity;
 import org.jooq.JoinType;
 // ...
 import org.jooq.Name;
@@ -93,7 +92,6 @@ import org.jooq.TableLike;
 import org.jooq.TableOnStep;
 import org.jooq.TableOptionalOnStep;
 import org.jooq.TablePartitionByStep;
-import org.jooq.UniqueKey;
 // ...
 // ...
 import org.jooq.tools.StringUtils;
@@ -293,26 +291,6 @@ abstract class AbstractTable<R extends Record> extends AbstractQueryPart impleme
     /**
      * {@inheritDoc}
      * <p>
-     * Subclasses should override this method
-     */
-    @Override
-    public Identity<R, ?> getIdentity() {
-        return null;
-    }
-
-    /**
-     * {@inheritDoc}
-     * <p>
-     * Subclasses may override this method
-     */
-    @Override
-    public UniqueKey<R> getPrimaryKey() {
-        return null;
-    }
-
-    /**
-     * {@inheritDoc}
-     * <p>
      * Subclasses may override this method
      */
     @Override
@@ -332,30 +310,10 @@ abstract class AbstractTable<R extends Record> extends AbstractQueryPart impleme
 
     /**
      * {@inheritDoc}
-     * <p>
-     * Subclasses should override this method
-     */
-    @Override
-    public List<UniqueKey<R>> getKeys() {
-        return Collections.emptyList();
-    }
-
-    /**
-     * {@inheritDoc}
      */
     @Override
     public final <O extends Record> List<ForeignKey<O, R>> getReferencesFrom(Table<O> other) {
         return other.getReferencesTo(this);
-    }
-
-    /**
-     * {@inheritDoc}
-     * <p>
-     * Subclasses should override this method
-     */
-    @Override
-    public List<ForeignKey<R, ?>> getReferences() {
-        return Collections.emptyList();
     }
 
     /**

--- a/jOOQ/src/main/java/org/jooq/impl/DAOImpl.java
+++ b/jOOQ/src/main/java/org/jooq/impl/DAOImpl.java
@@ -123,11 +123,6 @@ public abstract class DAOImpl<R extends UpdatableRecord<R>, P, T> implements DAO
         return Tools.configuration(configuration()).dialect();
     }
 
-    @Override
-    public /* non-final */ SQLDialect family() {
-        return dialect().family();
-    }
-
     /**
      * {@inheritDoc}
      * <p>

--- a/jOOQ/src/main/java/org/jooq/impl/Tools.java
+++ b/jOOQ/src/main/java/org/jooq/impl/Tools.java
@@ -2320,17 +2320,15 @@ final class Tools {
             /**
              * This callback is executed if {@link #unguarded()} has already been executed on the current stack.
              */
-            V guarded();
+            default V guarded() {
+			    return null;
+			}
         }
 
         /**
          * A default implementation for {@link GuardedOperation#guarded()}.
          */
         abstract static class AbstractGuardedOperation<V> implements GuardedOperation<V> {
-            @Override
-            public V guarded() {
-                return null;
-            }
         }
 
         /**

--- a/jOOQ/src/main/java/org/jooq/impl/Tools.java
+++ b/jOOQ/src/main/java/org/jooq/impl/Tools.java
@@ -2321,8 +2321,8 @@ final class Tools {
              * This callback is executed if {@link #unguarded()} has already been executed on the current stack.
              */
             default V guarded() {
-			    return null;
-			}
+                return null;
+            }
         }
 
         /**

--- a/jOOQ/src/main/java/org/jooq/impl/Tools.java
+++ b/jOOQ/src/main/java/org/jooq/impl/Tools.java
@@ -2326,12 +2326,6 @@ final class Tools {
         }
 
         /**
-         * A default implementation for {@link GuardedOperation#guarded()}.
-         */
-        abstract static class AbstractGuardedOperation<V> implements GuardedOperation<V> {
-        }
-
-        /**
          * Run an operation using a guard.
          */
         static final <V> V run(Guard guard, GuardedOperation<V> operation) {


### PR DESCRIPTION
This is a semantics-preserving automated refactoring that migrates existing method implementations in classes to the corresponding implemented interface methods as `default` methods. The tool **does not** add new code; it only rearranges *existing* code.

- We are evaluating a research prototype automated refactoring Eclipse plug-in called [Migrate Skeletal Implementation to Interface](https://github.com/khatchad/Migrate-Skeletal-Implementation-to-Interface-Refactoring). We have applied the tool to your project in the hopes of receiving feedback.
- The approach is very conservative. Specifically, it only performs a migration if the target interface is unambiguous. That may mean that not all changes that can be made were made. Please feel free to continue the refactoring manually if you wish.
- We only migrated methods declared in abstract classes. We believe such methods to be likely suitable default methods in corresponding interfaces.
- The source code should be semantically equivalent to the original.

Thank you for your help in this evaluation! Any feedback you can provide would be very helpful. In particular, we are interested if *each* of the proposed changes are helpful or not.