### PR TITLE
#3062 Work on adding ability to convert between collections and arrays.

### DIFF
--- a/jOOQ/src/main/java/org/jooq/tools/Convert.java
+++ b/jOOQ/src/main/java/org/jooq/tools/Convert.java
@@ -430,7 +430,7 @@ public final class Convert {
     /**
      * The converter to convert them all.
      */
-    private static class ConvertAll<U> implements Converter<Object, U> {
+    static class ConvertAll<U> implements Converter<Object, U> {
 
         /**
          * Generated UID
@@ -494,16 +494,31 @@ public final class Convert {
                     return convert(Arrays.toString((byte[]) from), toClass);
                 }
                 else if (fromClass.isArray()) {
+                    Object[] fromArray = (Object[]) from;
+
+                    if (Collection.class.isAssignableFrom(toClass) &&
+                            toClass.isAssignableFrom(ArrayList.class)) {
+                        return (U) new ArrayList(Arrays.asList(fromArray));
+                    }
+                    else if (Collection.class.isAssignableFrom(toClass) &&
+                            toClass.isAssignableFrom(LinkedHashSet.class)) {
+                        return (U) new LinkedHashSet(Arrays.asList(fromArray));
+                    }
 
                     // [#3443] Conversion from Object[] to JDBC Array
                     if (toClass == java.sql.Array.class) {
-                        return (U) new MockArray(null, (Object[]) from, fromClass);
+                        return (U) new MockArray(null, fromArray, fromClass);
                     }
                     else {
-                        return (U) convertArray((Object[]) from, toClass);
+                        return (U) convertArray(fromArray, toClass);
                     }
                 }
 
+                else if (toClass.isArray()
+                        && Collection.class.isAssignableFrom(fromClass)){
+                    Collection f = (Collection) from;
+                    return (U) f.toArray();
+                }
 
                 else if (toClass == Optional.class) {
                     return (U) Optional.of(from);

--- a/jOOQ/src/test/java/org/jooq/tools/ConvertTest.java
+++ b/jOOQ/src/test/java/org/jooq/tools/ConvertTest.java
@@ -28,8 +28,15 @@ public class ConvertTest {
 	@Test
 	public void testFromCollection(){
 		List<String> list = asList("Hello", "world", "!");
-
-		String[] arr = new Convert.ConvertAll<>(String[].class).from(list);
+		String[] arr = Convert.convertCollection(list, String[].class);
 		assertEquals(list, asList(arr));
+
+		String[] numStrings = new String[]{"1", "2", "3"};
+		List<Integer> integerList = asList(1, 2, 3);
+
+		String[] convertedNumString = Convert.convertCollection(integerList, String[].class);
+		assertTrue(Arrays.equals(numStrings, convertedNumString));
+
+		assertTrue(Arrays.equals(new String[0], Convert.convertCollection(new LinkedList<Integer>(), String[].class)));
 	}
 }

--- a/jOOQ/src/test/java/org/jooq/tools/ConvertTest.java
+++ b/jOOQ/src/test/java/org/jooq/tools/ConvertTest.java
@@ -1,0 +1,35 @@
+package org.jooq.tools;
+
+import org.junit.Test;
+
+import java.util.*;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by nfischer on 9/24/2016.
+ */
+public class ConvertTest {
+
+	@Test
+	public void testFromArray(){
+		String[] arr = new String[]{"Hello", "World", "!"};
+		List convertedList = Convert.convert(arr, List.class);
+		assertEquals(ArrayList.class, convertedList.getClass());
+		assertTrue(Arrays.equals(arr, convertedList.toArray()));
+
+		Set convertedSet = Convert.convert(arr, Set.class);
+		assertEquals(LinkedHashSet.class, convertedSet.getClass());
+		assertTrue(Arrays.equals(arr, convertedSet.toArray()));
+	}
+
+	@Test
+	public void testFromCollection(){
+		List<String> list = asList("Hello", "world", "!");
+
+		String[] arr = new Convert.ConvertAll<>(String[].class).from(list);
+		assertEquals(list, asList(arr));
+	}
+}


### PR DESCRIPTION
So this is not ready for merge, has some outstanding issues. 
- tests - I made `ConvertAll` package private so I could slap some unit tests in there. What is the correct place for tests?
- API - as you can see from the test, when converting from a collection you have to use `ConvertAll` directly, since adding another `convert(Collection<?> collection, Class<? extends T[]> type)` method would conflict, and changing the existing one might not be what you want to do.
