### PR TITLE
[#5333] Fix PG record parsing

### DIFF
--- a/jOOQ/src/main/java/org/jooq/DataType.java
+++ b/jOOQ/src/main/java/org/jooq/DataType.java
@@ -100,6 +100,11 @@ public interface DataType<T> extends Serializable {
      */
     DataType<T[]> getArrayDataType();
 
+    /**
+     * Retrieve the data type for single value of this data type.
+     */
+    DataType<?> getElementType();
+
 
 
 

--- a/jOOQ/src/main/java/org/jooq/impl/ArrayDataType.java
+++ b/jOOQ/src/main/java/org/jooq/impl/ArrayDataType.java
@@ -75,6 +75,11 @@ final class ArrayDataType<T> extends DefaultDataType<T[]> {
         return getArrayType(configuration, castTypeName);
     }
 
+    @Override
+    public final DataType<?> getElementType() {
+        return this.elementType;
+    }
+
     private static String getArrayType(Configuration configuration, String dataType) {
         switch (configuration.family()) {
             case HSQLDB:

--- a/jOOQ/src/main/java/org/jooq/impl/DefaultDataType.java
+++ b/jOOQ/src/main/java/org/jooq/impl/DefaultDataType.java
@@ -649,6 +649,11 @@ public class DefaultDataType<T> implements DataType<T> {
         return new ArrayDataType<T>(this);
     }
 
+    @Override
+    public DataType<?> getElementType() {
+        return this;
+    }
+
 
 
 

--- a/jOOQ/src/main/java/org/jooq/util/postgres/PostgresUtils.java
+++ b/jOOQ/src/main/java/org/jooq/util/postgres/PostgresUtils.java
@@ -40,9 +40,12 @@
  */
 package org.jooq.util.postgres;
 
-import static java.lang.Integer.toOctalString;
-import static org.jooq.tools.StringUtils.leftPad;
-import static org.jooq.tools.reflect.Reflect.on;
+import org.jooq.Converter;
+import org.jooq.Record;
+import org.jooq.exception.DataTypeException;
+import org.jooq.tools.reflect.Reflect;
+import org.jooq.types.DayToSecond;
+import org.jooq.types.YearToMonth;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -53,12 +56,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.jooq.Converter;
-import org.jooq.Record;
-import org.jooq.exception.DataTypeException;
-import org.jooq.tools.reflect.Reflect;
-import org.jooq.types.DayToSecond;
-import org.jooq.types.YearToMonth;
+import static java.lang.Integer.toOctalString;
+import static org.jooq.tools.StringUtils.leftPad;
+import static org.jooq.tools.reflect.Reflect.on;
 
 /**
  * A collection of utilities to cover the Postgres JDBC driver's missing
@@ -288,7 +288,7 @@ public class PostgresUtils {
      */
     @SuppressWarnings("null")
     private static List<String> toPGObjectOrArray(String input, char open, char close) {
-        List<String> values = new ArrayList<String>();
+        List<String> values = new ArrayList<>();
         int i = 0;
         int state = PG_OBJECT_INIT;
         StringBuilder sb = null;
@@ -434,6 +434,9 @@ public class PostgresUtils {
      * Create a Postgres string representation of an array
      */
     public static String toPGArrayString(Object[] value) {
+        if (value.length == 0) {
+            return "{}";
+        }
         StringBuilder sb = new StringBuilder();
         sb.append("{");
 
@@ -480,11 +483,15 @@ public class PostgresUtils {
      * Create a PostgreSQL string representation of a record.
      */
     public static String toPGString(Record r) {
+        final int len = r.size();
+        if (len == 0) {
+            return "()";
+        }
         StringBuilder sb = new StringBuilder();
         sb.append("(");
 
         String separator = "";
-        for (int i = 0; i < r.size(); i++) {
+        for (int i = 0; i < len; i++) {
             @SuppressWarnings({ "unchecked", "rawtypes" })
             Object a = ((Converter) r.field(i).getConverter()).to(r.get(i));
             sb.append(separator);
@@ -510,6 +517,9 @@ public class PostgresUtils {
      * Create a PostgreSQL string representation of a binary.
      */
     public static String toPGString(byte[] binary) {
+        if (binary.length == 0) {
+            return "";
+        }
         StringBuilder sb = new StringBuilder();
 
         for (byte b : binary) {


### PR DESCRIPTION
This commit extends the PG tokenization of records to handle the cases
of nested objects and arrays. It also adds support for java.time classes
in UDTs.
