### PR TITLE
Added hint for m2e to behave

### DIFF
--- a/jOOQ-codegen-maven/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/jOOQ-codegen-maven/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>generate</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <execute>
+          <runOnIncremental>false</runOnIncremental>
+          <runOnConfiguration>true</runOnConfiguration>
+        </execute>
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
Added hint for m2e to run generate goal on "configuration change", which basically
means on project imports and when pom.xml has bee modified. This makes
jOOQ projects compile properly when imported and also (for some weird reason)
fixes autoconfiguration of classpath for the generated resources.

Without this change most jOOQ+Eclipse users will need to add lots of Eclipse
specific dirt to their pom.xml file.

Closes #5582
