### PR TITLE
Fix for mock of delete

### DIFF
--- a/jOOQ/src/main/java/org/jooq/tools/jdbc/MockStatement.java
+++ b/jOOQ/src/main/java/org/jooq/tools/jdbc/MockStatement.java
@@ -188,7 +188,8 @@ public class MockStatement extends JDBC41Statement implements CallableStatement 
         );
 
         result = data.execute(context);
-        return result != null && result.length > 0 && result[resultIndex].data != null;
+
+        return localSql.startsWith("select");
     }
 
     private static final int[] unbox(List<Integer> list) {
@@ -229,7 +230,13 @@ public class MockStatement extends JDBC41Statement implements CallableStatement 
     @Override
     public int getUpdateCount() throws SQLException {
         checkNotClosed();
-        return (result != null && resultIndex < result.length) && result[resultIndex].data == null ? result[resultIndex].rows : -1;
+        if (result != null && resultIndex < result.length) {
+        	if (!sql.get(0).startsWith("select") && result[resultIndex].data != null && result[resultIndex].data.size() > 0) {
+        		return result[resultIndex].data.get(0).get(0, Integer.class);
+        	}
+        	return result[resultIndex].rows;
+        }
+        return -1;
     }
 
     @Override


### PR DESCRIPTION
Mocks for delete always returns 0.  Instead, it should get the return value from MockStatement.getUpdateCount(). To accomplish this, MockStatement.execute0 should return false for non-queries, such as delete, to indicate that a result set is not available, and should be obtained via call to getUpdateCount(). Also, changes need to be made to MockStatement.getUpdateCount() to return value from data as an integer for non-queries.