### PR TITLE
[#5858] prefix encoding of binary types with tag and decode in loadInto conversion

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/ResultImpl.java
+++ b/jOOQ/src/main/java/org/jooq/impl/ResultImpl.java
@@ -814,8 +814,7 @@ final class ResultImpl<R extends Record> implements Result<R>, AttachableInterna
 
     private final Object formatJSON0(Object value) {
         if (value instanceof byte[])
-            return DatatypeConverter.printBase64Binary((byte[]) value);
-
+            return "BASE64:" + DatatypeConverter.printBase64Binary((byte[]) value);
         return value;
     }
 
@@ -831,7 +830,7 @@ final class ResultImpl<R extends Record> implements Result<R>, AttachableInterna
             formatted += visual ? "{null}" : null;
         }
         else if (value.getClass() == byte[].class) {
-            formatted += DatatypeConverter.printBase64Binary((byte[]) value);
+            formatted += "BASE64:" + DatatypeConverter.printBase64Binary((byte[]) value);
         }
         else if (value.getClass().isArray()) {
             formatted += Arrays.toString((Object[]) value);

--- a/jOOQ/src/main/java/org/jooq/tools/Convert.java
+++ b/jOOQ/src/main/java/org/jooq/tools/Convert.java
@@ -73,6 +73,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import javax.xml.bind.DatatypeConverter;
 
 // ...
 import org.jooq.Converter;
@@ -535,7 +536,12 @@ public final class Convert {
                         return (U)b.array();
                     }
                     else {
-                        return (U) from.toString().getBytes();
+                        String val = from.toString();
+                        if (val.startsWith("BASE64:")) {
+                            return (U) DatatypeConverter.parseBase64Binary(val.substring("BASE64:".length()));
+                        } else {
+                            return (U) val.getBytes();
+                        }
                     }
                 }
 


### PR DESCRIPTION
[#5858] prefix base64 encoding of binary types with 'BASE64:' and decode these values when encountering them in loadInto conversion