### PR TITLE
[#5898] Field.contains(T) must not call toString() on T value

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/AbstractField.java
+++ b/jOOQ/src/main/java/org/jooq/impl/AbstractField.java
@@ -837,7 +837,7 @@ abstract class AbstractField<T> extends AbstractQueryPart implements Field<T> {
 
     @Override
     public final Condition startsWith(T value) {
-        Field<String> concat = DSL.concat(Tools.escapeForLike(value), inline("%"));
+        Field<String> concat = DSL.concat(Tools.escapeForLike(value, dataType), inline("%"));
         return like(concat, Tools.ESCAPE);
     }
 
@@ -849,7 +849,7 @@ abstract class AbstractField<T> extends AbstractQueryPart implements Field<T> {
 
     @Override
     public final Condition endsWith(T value) {
-        Field<String> concat = DSL.concat(inline("%"), Tools.escapeForLike(value));
+        Field<String> concat = DSL.concat(inline("%"), Tools.escapeForLike(value, dataType));
         return like(concat, Tools.ESCAPE);
     }
 

--- a/jOOQ/src/main/java/org/jooq/impl/Contains.java
+++ b/jOOQ/src/main/java/org/jooq/impl/Contains.java
@@ -96,7 +96,7 @@ final class Contains<T> extends AbstractCondition {
             Field<String> concat;
 
             if (rhs == null) {
-                concat = DSL.concat(inline("%"), Tools.escapeForLike(value, configuration), inline("%"));
+                concat = DSL.concat(inline("%"), Tools.escapeForLike(value, lhs.getDataType(), configuration), inline("%"));
             }
             else {
                 concat = DSL.concat(inline("%"), Tools.escapeForLike(rhs, configuration), inline("%"));

--- a/jOOQ/src/main/java/org/jooq/impl/Tools.java
+++ b/jOOQ/src/main/java/org/jooq/impl/Tools.java
@@ -2186,28 +2186,21 @@ final class Tools {
     /**
      * Utility method to escape strings or "toString" other objects
      */
-    static final Field<String> escapeForLike(Object value) {
-        return escapeForLike(value, new DefaultConfiguration());
+    static final Field<?> escapeForLike(Object value, DataType<?> type) {
+        return escapeForLike(value, type, new DefaultConfiguration());
     }
 
     /**
      * Utility method to escape strings or "toString" other objects
      */
-    static final Field<String> escapeForLike(Object value, Configuration configuration) {
+    static final Field<?> escapeForLike(Object value, DataType<?> type, Configuration configuration) {
         if (value != null && value.getClass() == String.class) {
-
-
-
-
-
-
-
             {
-                return val(escape("" + value, ESCAPE));
+                return val(escape(value.toString(), ESCAPE));
             }
         }
         else {
-            return val("" + value);
+            return val(value, type);
         }
     }
 

--- a/jOOQ/src/main/resources/META-INF/ABOUT.txt
+++ b/jOOQ/src/main/resources/META-INF/ABOUT.txt
@@ -21,6 +21,7 @@ Authors and contributors of jOOQ or parts of jOOQ in alphabetical order:
 - Joseph B Phillips
 - Joseph Pachod
 - Laurent Pireyn
+- Luc Marchaud
 - Lukas Eder
 - Matti Tahvonen
 - Michael Doberenz


### PR DESCRIPTION
Suggestion for issue #5898 

I found same issue with Field.startsWith(T) and Field.endsWith(T) with same cause, so I include fix here.