### PR TITLE
Fix typo in `having` example java code

### DIFF
--- a/jOOQ-manual/src/main/resources/org/jooq/web/manual-3.9.xml
+++ b/jOOQ-manual/src/main/resources/org/jooq/web/manual-3.9.xml
@@ -4488,7 +4488,7 @@ FROM BOOK
 GROUP BY AUTHOR_ID
 HAVING COUNT(*) >= 2
 ]]>&#160;</sql>
-<java><![CDATA[create.select(BOOK.AUTHOR_ID, count(*))
+<java><![CDATA[create.select(BOOK.AUTHOR_ID, count())
       .from(BOOK)
       .groupBy(AUTHOR_ID)
       .having(count().greaterOrEqual(2))


### PR DESCRIPTION
You can't do `count(*)` in Java.