### PR TITLE
Provide Scala conversions as both Trait & Object

### DIFF
--- a/jOOQ-scala/src/main/scala/org/jooq/scalaextensions/Conversions.scala
+++ b/jOOQ-scala/src/main/scala/org/jooq/scalaextensions/Conversions.scala
@@ -90,7 +90,7 @@ trait Conversions {
   // Enhanced jOOQ types
   // -------------------------------------------------------------------------
 
-  implicit class SQLInterpolation(val sc : StringContext) extends AnyVal {
+  implicit class SQLInterpolation(val sc : StringContext) {
 
     @PlainSQL
     def sql(args: Any*) : SQL = DSL.sql(string(args), args.asInstanceOf[Seq[AnyRef]] : _*)
@@ -199,7 +199,7 @@ trait Conversions {
    * A Scala-esque representation of {@link org.jooq.Field}, adding overloaded
    * operators for common jOOQ operations to arbitrary fields
    */
-  implicit class ScalaField[T](val field : Field[T]) extends AnyVal {
+  implicit class ScalaField[T](val field : Field[T]) {
 
     // String operations
     // -----------------
@@ -257,7 +257,7 @@ trait Conversions {
    * A Scala-esque representation of {@link org.jooq.Field}, adding overloaded
    * operators for common jOOQ operations to numeric fields
    */
-  implicit class ScalaNumberField[T <: Number](val field : Field[T]) extends AnyVal {
+  implicit class ScalaNumberField[T <: Number](val field : Field[T]) {
 
     // ------------------------------------------------------------------------
     // Arithmetic operations

--- a/jOOQ-scala/src/main/scala/org/jooq/scalaextensions/Conversions.scala
+++ b/jOOQ-scala/src/main/scala/org/jooq/scalaextensions/Conversions.scala
@@ -84,7 +84,7 @@ import scala.collection.convert.WrapAsScala
  * @author Lukas Eder
  * @author Eric Peters
  */
-object Conversions {
+trait Conversions {
 
   // -------------------------------------------------------------------------
   // Enhanced jOOQ types
@@ -815,3 +815,5 @@ object Conversions {
 // [jooq-tools] START [handler]
 // [jooq-tools] END [handler]
 }
+
+object Conversions extends Conversions


### PR DESCRIPTION
With `Conversions` available as a trait, downstream users can mix the trait into their own extension classes, to minimise imports.

Due to the `object Conversions extends Conversions`, functionality is unchanged for users who don't want to make use of this.

Usage example:

```scala
package somepackage

import org.jooq.Record
import org.jooq.scalaextensions.Conversions

object MyFancyJooqExtensions extends Conversions {
  implicit class ExtendRecordWithSomething(record: Record) {
    ...
  }
}

// in another file...

import somepackage.MyFancyJooqExtensions._ // Conversions are also provided by this import.
```

Edit: I had to turn the implicit classes into reference (from value) classes - see my note in my second commit about the (should be limited) effect of that.