### PR TITLE
In jOOQ-spring-boot-example, use jooq starter instead of jdbc starter

### DIFF
--- a/jOOQ-examples/jOOQ-spring-boot-example/pom.xml
+++ b/jOOQ-examples/jOOQ-spring-boot-example/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.3.RELEASE</version>
+        <version>1.5.4.RELEASE</version>
     </parent>
 
     <groupId>org.jooq</groupId>
@@ -33,12 +33,7 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-jdbc</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jooq</groupId>
-            <artifactId>jooq</artifactId>
+            <artifactId>spring-boot-starter-jooq</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Jooq starter includes jdbc starter as transitive dependency, so we can use this and jooq is obtained from jooq starter.
also upgrades to latest spring boot version