### PR TITLE
Optimization of {ULong,UInteger,UShort}.toBigInteger

### DIFF
--- a/jOOQ/src/main/java/org/jooq/types/UInteger.java
+++ b/jOOQ/src/main/java/org/jooq/types/UInteger.java
@@ -16,6 +16,7 @@
 package org.jooq.types;
 
 import java.io.ObjectStreamException;
+import java.math.BigInteger;
 
 /**
  * The <code>unsigned int</code> type
@@ -271,6 +272,11 @@ public final class UInteger extends UNumber implements Comparable<UInteger> {
     @Override
     public double doubleValue() {
         return value;
+    }
+
+    @Override
+    public BigInteger toBigInteger() {
+        return BigInteger.valueOf(value);
     }
 
     @Override

--- a/jOOQ/src/main/java/org/jooq/types/ULong.java
+++ b/jOOQ/src/main/java/org/jooq/types/ULong.java
@@ -144,6 +144,11 @@ public final class ULong extends UNumber implements Comparable<ULong> {
     }
 
     @Override
+    public BigInteger toBigInteger() {
+        return value;
+    }
+
+    @Override
     public int hashCode() {
         return value.hashCode();
     }

--- a/jOOQ/src/main/java/org/jooq/types/UShort.java
+++ b/jOOQ/src/main/java/org/jooq/types/UShort.java
@@ -15,6 +15,8 @@
  */
 package org.jooq.types;
 
+import java.math.BigInteger;
+
 /**
  * The <code>unsigned short</code> type
  *
@@ -128,6 +130,11 @@ public final class UShort extends UNumber implements Comparable<UShort> {
     @Override
     public double doubleValue() {
         return value;
+    }
+
+    @Override
+    public BigInteger toBigInteger() {
+        return BigInteger.valueOf(value);
     }
 
     @Override


### PR DESCRIPTION
Now, UNumber.toBigInteger implemented as new BigInteger(toString());
BigInteger is immutable, so we can just return this.value for ULong, and use BigInteger.valueOf for other types