### PR TITLE
Support system properties in Maven code generation

### DIFF
--- a/jOOQ-codegen-maven/src/main/java/org/jooq/util/maven/Plugin.java
+++ b/jOOQ-codegen-maven/src/main/java/org/jooq/util/maven/Plugin.java
@@ -95,7 +95,9 @@ public class Plugin extends AbstractMojo {
     /**
      * Whether to skip the execution of the Maven Plugin for this module.
      */
-    @Parameter
+    @Parameter(
+        property = "jooq.skip"
+    )
     private boolean                      skip;
 
     /**


### PR DESCRIPTION
Adds a property `jooq.codegen.skip`, so generation can be skipped dynamically via `-Djooq.codegen.skip`.

There may be situations where you want to skip execution of `jooq-codegen-maven` for a single run, for example when you know that your db schema has not changed and you want to save some time. If I don't miss anything, currently you can only skip codegen by changing the pom and configuring `<skip>true</skip>`. Most Maven plugins have a `<plugin>.skip` property to make this easier. This PR adds such a property.

With this change you can skip jOOQ codegen e.g. by running

    mvn install -Djooq.codegen.skip

which is equivalent to

    mvn install -Djooq.codegen.skip=true

This PR is related to #4505.
  