### PR TITLE
[7049] Add type information in Tables.scala to avoid scalac unused import warning

### DIFF
--- a/jOOQ-codegen/src/main/java/org/jooq/util/JavaGenerator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/util/JavaGenerator.java
@@ -2766,7 +2766,7 @@ public class JavaGenerator extends AbstractGenerator {
                 out.tab(1).javadoc(comment);
 
                 if (scala)
-                	out.tab(1).println("val %s = %s", id, fullId);
+                	out.tab(1).println("val %s : %s = %s", id, className, fullId);
                 else
                 	out.tab(1).println("public static final %s %s = %s;", className, id, fullId);
             }


### PR DESCRIPTION

Fixes minor issue: https://github.com/jOOQ/jOOQ/issues/7049

I've previously signed/authorized the jOOQ contribution agreement