### PR TITLE
[7051] Fix generated scala deprecation warning

### DIFF
--- a/jOOQ-codegen/src/main/java/org/jooq/util/JavaGenerator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/util/JavaGenerator.java
@@ -3633,7 +3633,7 @@ public class JavaGenerator extends AbstractGenerator {
         printClassAnnotations(out, schema);
 
         if (scala) {
-            out.println("class %s(alias : %s, aliased : %s[%s], parameters : %s[ %s[_] ]) extends %s[%s](alias, %s, aliased, parameters, \"%s\")[[before= with ][separator= with ][%s]] {",
+            out.println("class %s(alias : %s, aliased : %s[%s], parameters : %s[ %s[_] ]) extends %s[%s](alias, %s, aliased, parameters, DSL.comment(\"%s\"))[[before= with ][separator= with ][%s]] {",
                     className, Name.class, Table.class, recordType, out.ref("scala.Array"), Field.class, TableImpl.class, recordType, schemaId, escapeString(comment), interfaces);
         }
         else {


### PR DESCRIPTION
I don't know enough about why this was deprecated: https://github.com/jOOQ/jOOQ/blob/f58e7d7ef6430058925551fc673ea74f9c9d7cc3/jOOQ/src/main/java/org/jooq/impl/TableImpl.java#L146 but this PR basically does the same thing, just more explicitly for the scala-only generated code.

My instinct suggests that this PR might not actually be the correct solution, and the one helper function should actually be "undeprecated" since the original `JavaGenerator` usage seems like a cleaner API interface with `TableImpl` .. are there additional deprecation warnings on the java side here: https://github.com/jOOQ/jOOQ/blob/eec46ca0835bb5e5f433ad76adc75ed31fabb0bc/jOOQ-codegen/src/main/java/org/jooq/util/JavaGenerator.java#L3669-L3670 ?  (although those look like they aren't using `TableImpl` but a column-impl)