### PR TITLE
Formatting tweaks

### DIFF
--- a/jOOQ-codegen/src/main/java/org/jooq/util/JavaGenerator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/util/JavaGenerator.java
@@ -3075,7 +3075,7 @@ public class JavaGenerator extends AbstractGenerator {
                     separator,
                     generateImmutablePojos() ? "" : "private var ",
                     getStrategy().getJavaMemberName(column, Mode.POJO),
-                    StringUtils.rightPad(out.ref(getJavaType(column.getType(resolver(Mode.POJO)), Mode.POJO)), maxLength));
+                    out.ref(getJavaType(column.getType(resolver(Mode.POJO)), Mode.POJO)));
 
                 separator = ", ";
             }
@@ -3520,7 +3520,7 @@ public class JavaGenerator extends AbstractGenerator {
             }
 
             out.tab(2).println();
-            out.tab(2).println("sb.append(\")\");");
+            out.tab(2).println("sb.append(\")\")");
 
             out.tab(2).println("return sb.toString");
             out.tab(1).println("}");

--- a/jOOQ-scala_2.12/src/main/scala/org/jooq/scalaextensions/Conversions.scala
+++ b/jOOQ-scala_2.12/src/main/scala/org/jooq/scalaextensions/Conversions.scala
@@ -44,7 +44,7 @@ import org.jooq.impl._
 
 // Avoid ambiguity with the internal org.jooq.impl.Array type.
 import scala.Array
-import scala.collection.convert.WrapAsScala
+import scala.collection.JavaConverters._
 
 /**
  * jOOQ type conversions used to enhance the jOOQ Java API with Scala Traits
@@ -172,7 +172,7 @@ object Conversions {
     def fetchAnyOptionArray            ()                                                         : Option[Array[AnyRef]]       = Option(query.fetchAnyArray)
     def fetchAnyOptionInto[E]          (newType : Class[_ <: E])                                  : Option[E]                   = Option(query.fetchAnyInto(newType))
     def fetchAnyOptionInto[Z <: Record](table : Table[Z])                                         : Option[Z]                   = Option(query.fetchAnyInto(table))
-    def fetchAnyOptionMap              ()                                                         : Option[Map[String, AnyRef]] = Option(query.fetchAnyMap).map(WrapAsScala.mapAsScalaMap)
+    def fetchAnyOptionMap              ()                                                         : Option[Map[String, AnyRef]] = Option(query.fetchAnyMap).map{ _.asScala }
 
     def fetchOneOption                 ()                                                         : Option[R]                   = Option(query.fetchOne)
     def fetchOneOption[E]              (mapper : RecordMapper[_ >: R, E])                         : Option[E]                   = Option(query.fetchOne(mapper))
@@ -188,7 +188,7 @@ object Conversions {
     def fetchOneOptionArray            ()                                                         : Option[Array[AnyRef]]       = Option(query.fetchOneArray)
     def fetchOneOptionInto[E]          (newType : Class[_ <: E])                                  : Option[E]                   = Option(query.fetchOneInto(newType))
     def fetchOneOptionInto[Z <: Record](table : Table[Z])                                         : Option[Z]                   = Option(query.fetchOneInto(table))
-    def fetchOneOptionMap              ()                                                         : Option[Map[String, AnyRef]] = Option(query.fetchOneMap).map(WrapAsScala.mapAsScalaMap)
+    def fetchOneOptionMap              ()                                                         : Option[Map[String, AnyRef]] = Option(query.fetchOneMap).map{ _.asScala }
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
This fetch based upon the mapper still seems weird: https://github.com/jOOQ/jOOQ/pull/7077/commits/02e7e62c5dd22460dcf69521b27f7f0f5168b63f#diff-c9f97bdfa70478b5ea299842ddbc660aL162

I'm not evem sure how this compile: https://github.com/jOOQ/jOOQ/blob/b2f9a4e5ad55b71b760a73f1e64c56cc2cce2fb6/jOOQ/src/main/java/org/jooq/ResultQuery.java#L652 isn't RecordMapper defined as `? extends R`?

IntelliJ doesn't like this line and complains about it, but the scala compiler "works"  Despite the fact we previously had a made-up bounds for `RecordMapper`

punting it for now because I couldn't get a typing to work properly, and I don't understand/didn't dive into how the mapper is suppose to work
