### PR TITLE
Allow usage of derived table as aliased parameter of TableImpl constructor

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/TableImpl.java
+++ b/jOOQ/src/main/java/org/jooq/impl/TableImpl.java
@@ -153,8 +153,14 @@ public class TableImpl<R extends Record> extends AbstractTable<R> {
 
         this.fields = new Fields<R>();
 
-        if (aliased != null)
-            alias = new Alias<Table<R>>(aliased, name);
+        if (aliased != null) {
+            Alias<Table<R>> existingAlias = Tools.alias(aliased);
+            if (existingAlias != null) {
+                alias = existingAlias;
+            } else {
+                alias = new Alias<Table<R>>(aliased, name);
+            }
+        }
         else
             alias = null;
 

--- a/jOOQ/src/main/java/org/jooq/impl/Tools.java
+++ b/jOOQ/src/main/java/org/jooq/impl/Tools.java
@@ -4198,11 +4198,11 @@ final class Tools {
             return null;
     }
 
-    static final Alias<? extends Table<?>> alias(Table<?> table) {
+    static final <R extends Record> Alias<Table<R>> alias(Table<R> table) {
         if (table instanceof TableImpl)
-            return ((TableImpl<?>) table).alias;
+            return ((TableImpl<R>) table).alias;
         else if (table instanceof TableAlias)
-            return ((TableAlias<?>) table).alias;
+            return ((TableAlias<R>) table).alias;
         else
             return null;
     }


### PR DESCRIPTION
This is following up my [post in jOOQ UG](https://groups.google.com/forum/#!topic/jooq-user/YXUtvMP3GFI) 
I'm terribly sorry if it's a hack! I tested that it solves my specific scenario but I don't know how to check whether it doesn't create a problem.
Anyway, @lukaseder, please regard this as a suggestion, nothing more! Thank you!