### PR TITLE
More extensible LoggerListener

### DIFF
--- a/jOOQ/src/main/java/org/jooq/tools/LoggerListener.java
+++ b/jOOQ/src/main/java/org/jooq/tools/LoggerListener.java
@@ -80,7 +80,7 @@ public class LoggerListener extends DefaultExecuteListener {
      */
     private static final long serialVersionUID = 7399239846062763212L;
 
-    private static final JooqLogger log   = JooqLogger.getLogger(LoggerListener.class);
+    protected static final JooqLogger log   = JooqLogger.getLogger(LoggerListener.class);
 
     @Override
     public void renderEnd(ExecuteContext ctx) {
@@ -197,7 +197,11 @@ public class LoggerListener extends DefaultExecuteListener {
         return result;
     }
 
-    private void logMultiline(String comment, String message, Level level) {
+    /**
+     * Prints the given message in multiple logging statements, separated by newline,
+     * and prefixing the first line with the given comment.
+     */
+    protected void logMultiline(String comment, String message, Level level) {
         for (String line : message.split("\n")) {
             if (level == Level.FINE) {
                 log.debug(comment, line);


### PR DESCRIPTION
Making it possible to extend the multi line logging behavior.

I send logging events to ElasticSearch, and multi line records with a table view is nearly useless. Changing the access modifier from private to protected, an extension can easily change these behaviors, achieving the result below with minimal code.

Original code output:
![kibana-jooq-original](https://user-images.githubusercontent.com/18003301/36310399-2d4cc488-1328-11e8-975b-3e748ff75171.png)

Modified code output:
![kibana-jooq-modified](https://user-images.githubusercontent.com/18003301/36310408-36195bc6-1328-11e8-80a8-b1212dbd1520.png)
