### PR TITLE
[#7324] Support Kotlin data classes in DefaultRecordMapper

### DIFF
--- a/jOOQ/pom.xml
+++ b/jOOQ/pom.xml
@@ -101,6 +101,11 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+            <version>1.2.30</version>
+        </dependency>
 
         <!-- From JDK 9 onwards, the JAXB dependency needs to be made explicit -->
         <dependency>

--- a/jOOQ/pom.xml
+++ b/jOOQ/pom.xml
@@ -101,11 +101,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-reflect</artifactId>
-            <version>1.2.30</version>
-        </dependency>
 
         <!-- From JDK 9 onwards, the JAXB dependency needs to be made explicit -->
         <dependency>

--- a/jOOQ/src/main/java/org/jooq/impl/DefaultRecordMapper.java
+++ b/jOOQ/src/main/java/org/jooq/impl/DefaultRecordMapper.java
@@ -50,6 +50,7 @@ import static org.jooq.impl.Tools.getMatchingMembers;
 import static org.jooq.impl.Tools.getMatchingSetters;
 import static org.jooq.impl.Tools.getPropertyName;
 import static org.jooq.impl.Tools.hasColumnAnnotations;
+import static org.jooq.impl.Tools.fieldNameStrings;
 import static org.jooq.tools.reflect.Reflect.accessible;
 
 import java.beans.ConstructorProperties;
@@ -79,6 +80,11 @@ import java.util.stream.Stream;
 
 import javax.persistence.Column;
 
+import kotlin.jvm.JvmClassMappingKt;
+import kotlin.reflect.KClass;
+import kotlin.reflect.KFunction;
+import kotlin.reflect.KParameter;
+import kotlin.reflect.full.KClasses;
 import org.jooq.Attachable;
 import org.jooq.Configuration;
 import org.jooq.Field;
@@ -340,6 +346,33 @@ public class DefaultRecordMapper<R extends Record, E> implements RecordMapper<R,
         // [#2989] [#2836] Records are mapped
         if (AbstractRecord.class.isAssignableFrom(type)) {
             delegate = (RecordMapper<R, E>) new RecordToRecordMapper();
+            return;
+        }
+
+        // [#7324] Map Kotlin data classes
+        KClass<? extends E> kotlinClass = JvmClassMappingKt.getKotlinClass(type);
+        if (kotlinClass.isData()) {
+            KFunction<? extends E> primaryConstructor = KClasses.getPrimaryConstructor(kotlinClass);
+            List<KParameter> parameters = primaryConstructor.getParameters();
+
+            if (parameters.size() != fields.length) {
+                throw new MappingException("Primary constructor of Kotlin data class " + type + " did not match row type " + rowType);
+            }
+
+            for (String fieldName : fieldNameStrings(fields)) {
+                String name = StringUtils.toCamelCaseLC(fieldName);
+                boolean found = false;
+                for (KParameter kParameter : parameters) {
+                    String parameterName = kParameter.getName();
+                    if (name.equals(parameterName)) {
+                        found = true;
+                    }
+                }
+                if (!found) {
+                    throw new MappingException("Primary constructor of Kotlin data class " + type + " did not match row type " + rowType);
+                }
+            }
+            delegate = new KotlinDataClassMapper(primaryConstructor);
             return;
         }
 
@@ -978,6 +1011,44 @@ public class DefaultRecordMapper<R extends Record, E> implements RecordMapper<R,
             catch (Exception e) {
                 throw new MappingException("An error ocurred when mapping record to " + type, e);
             }
+        }
+    }
+
+    private class KotlinDataClassMapper implements RecordMapper<R, E> {
+
+        private final KFunction<? extends E> constructor;
+        private final List<String> parameterNames;
+        private final Class[] parameterTypes;
+        private final Object[] parameterValues;
+
+        KotlinDataClassMapper(KFunction<? extends E> constructor) {
+            this.constructor = constructor;
+            int n = constructor.getParameters().size();
+            this.parameterNames = new ArrayList<>(n);
+            this.parameterValues = new Object[n];
+            this.parameterTypes = new Class[n];
+
+            List<KParameter> parameters = constructor.getParameters();
+            for (int i = 0; i < parameters.size(); i++) {
+                KParameter kParam = parameters.get(i);
+                parameterNames.add(kParam.getName());
+                parameterTypes[i] = JvmClassMappingKt.getJavaClass(((KClass<?>) kParam.getType().getClassifier()));
+            }
+        }
+
+        @Override
+        public E map(R record) {
+            for (int i = 0; i < fields.length; i++) {
+                String name = StringUtils.toCamelCaseLC(fields[i].getName());
+                int index = parameterNames.indexOf(name);
+                if (index < 0) {
+                    throw new MappingException("An error ocurred when mapping record to " + type);
+                }
+                parameterValues[index] = record.get(i);
+            }
+
+            Object[] converted = Convert.convert(parameterValues, parameterTypes);
+            return constructor.call(converted);
         }
     }
 

--- a/jOOQ/src/main/resources/META-INF/ABOUT.txt
+++ b/jOOQ/src/main/resources/META-INF/ABOUT.txt
@@ -55,6 +55,7 @@ Authors and contributors of jOOQ or parts of jOOQ in alphabetical order:
 - Victor Z. Peng
 - Vladimir Kulev
 - Vladimir Vinogradov
+- Vojtech Polivka
 - Wang Gaoyuan
 - Zoltan Tamasi
 

--- a/jOOQ/src/main/resources/META-INF/ABOUT.txt
+++ b/jOOQ/src/main/resources/META-INF/ABOUT.txt
@@ -55,7 +55,6 @@ Authors and contributors of jOOQ or parts of jOOQ in alphabetical order:
 - Victor Z. Peng
 - Vladimir Kulev
 - Vladimir Vinogradov
-- Vojtech Polivka
 - Wang Gaoyuan
 - Zoltan Tamasi
 


### PR DESCRIPTION
My naive attempt to leverage Kotlin `@Metadata` when mapping to Kotlin data classes.

Only [primary constructors](https://kotlinlang.org/docs/reference/classes.html#constructors) are considered. If the number of parameter matches the number of fields in the record, their names are checked. If all the names match the record is then mapped to the corresponding parameters by the names. 

If some of the conditions are not met an exception is thrown. I don't think we should default to any other mapping strategies for Kotlin data classes as not-matching the property names can lead to silent errors.