### PR TITLE
#7301: Allow customization of LoggerListener

### DIFF
--- a/jOOQ-meta/src/main/java/org/jooq/util/BufferedLog.java
+++ b/jOOQ-meta/src/main/java/org/jooq/util/BufferedLog.java
@@ -207,6 +207,11 @@ public class BufferedLog implements Log {
     }
 
     @Override
+    public boolean isWarnEnabled() {
+        return delegate.isWarnEnabled();
+    }
+
+    @Override
     public void warn(Object message) {
         delegate.warn(message);
         messages.add(message(WARN, message));
@@ -228,6 +233,11 @@ public class BufferedLog implements Log {
     public void warn(Object message, Object details, Throwable throwable) {
         delegate.warn(message, details, throwable);
         messages.add(message(WARN, message, details, throwable));
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return delegate.isErrorEnabled();
     }
 
     @Override

--- a/jOOQ/src/main/java/org/jooq/Log.java
+++ b/jOOQ/src/main/java/org/jooq/Log.java
@@ -162,6 +162,11 @@ public interface Log {
     void info(Object message, Object details, Throwable throwable);
 
     /**
+     * Check if <code>WARN</code> level logging is enabled.
+     */
+    boolean isWarnEnabled();
+
+    /**
      * Log a message in <code>WARN</code> level.
      *
      * @param message The log message
@@ -196,6 +201,11 @@ public interface Log {
     void warn(Object message, Object details, Throwable throwable);
 
     /**
+     * Check if <code>ERROR</code> level logging is enabled.
+     */
+    boolean isErrorEnabled();
+
+    /**
      * Log a message in <code>ERROR</code> level.
      *
      * @param message The log message
@@ -228,6 +238,84 @@ public interface Log {
      *            message
      */
     void error(Object message, Object details, Throwable throwable);
+
+    default boolean isEnabled(final Log.Level level) {
+        switch (level) {
+            case TRACE: return isTraceEnabled();
+            case DEBUG: return isDebugEnabled();
+            case INFO: return isInfoEnabled();
+            case WARN: return isWarnEnabled();
+            case ERROR: return isErrorEnabled();
+            case FATAL: return isErrorEnabled();
+            default: return false;
+        }
+    }
+
+    default void log(final Object message, final Log.Level level) {
+        log(message, (Object) null, level);
+    }
+
+    default void log(final Object message, final Object details, final Log.Level level) {
+        switch (level) {
+            case TRACE: {
+                trace(message, details);
+                return;
+            }
+            case DEBUG: {
+                debug(message, details);
+                return;
+            }
+            case INFO: {
+                info(message, details);
+                return;
+            }
+            case WARN: {
+                warn(message, details);
+                return;
+            }
+            case ERROR: {
+                error(message, details);
+                return;
+            }
+            case FATAL: {
+                error(message, details);
+                return;
+            }
+        }
+    }
+
+    default void log(final Object message, final Throwable throwable, final Log.Level level) {
+        log(message, null, throwable, level);
+    }
+
+    default void log(final Object message, final Object details, final Throwable throwable, final Log.Level level) {
+        switch (level) {
+            case TRACE: {
+                trace(message, details, throwable);
+                return;
+            }
+            case DEBUG: {
+                debug(message, details, throwable);
+                return;
+            }
+            case INFO: {
+                info(message, details, throwable);
+                return;
+            }
+            case WARN: {
+                warn(message, details, throwable);
+                return;
+            }
+            case ERROR: {
+                error(message, details, throwable);
+                return;
+            }
+            case FATAL: {
+                error(message, details, throwable);
+                return;
+            }
+        }
+    }
 
     /**
      * The log level.

--- a/jOOQ/src/main/java/org/jooq/conf/Settings.java
+++ b/jOOQ/src/main/java/org/jooq/conf/Settings.java
@@ -8,6 +8,8 @@
 
 package org.jooq.conf;
 
+import org.jooq.Log;
+
 import java.io.Serializable;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -65,6 +67,22 @@ public class Settings
     protected StatementType statementType = StatementType.PREPARED_STATEMENT;
     @XmlElement(defaultValue = "true")
     protected Boolean executeLogging = true;
+    @XmlElement(defaultValue = "DEBUG")
+    protected Log.Level executeLoggingBindVariables = Log.Level.DEBUG;
+    @XmlElement(defaultValue = "false")
+    protected Boolean executeLoggingAbbreviatedBindVariables = false;
+    @XmlElement(defaultValue = "DEBUG")
+    protected Log.Level executeLoggingSqlString = Log.Level.DEBUG;
+    @XmlElement(defaultValue = "DEBUG")
+    protected Log.Level executeLoggingResult = Log.Level.DEBUG;
+    @XmlElement(defaultValue = "5")
+    protected Integer executeLoggingResultNumberOfRows = 5;
+    @XmlElement(defaultValue = "50")
+    protected Integer executeLoggingResultNumberOfColumns = 50;
+    @XmlElement(defaultValue = "DEBUG")
+    protected Log.Level executeLoggingRoutine = Log.Level.DEBUG;
+    @XmlElement(defaultValue = "DEBUG")
+    protected Log.Level executeLoggingException = Log.Level.DEBUG;
     @XmlElement(defaultValue = "false")
     protected Boolean executeWithOptimisticLocking = false;
     @XmlElement(defaultValue = "false")
@@ -451,6 +469,70 @@ public class Settings
      */
     public void setExecuteLogging(Boolean value) {
         this.executeLogging = value;
+    }
+
+    public Log.Level getExecuteLoggingBindVariables() {
+        return executeLoggingBindVariables;
+    }
+
+    public void setExecuteLoggingBindVariables(final Log.Level executeLoggingBindVariables) {
+        this.executeLoggingBindVariables = executeLoggingBindVariables;
+    }
+
+    public Boolean isExecuteLoggingAbbreviatedBindVariables() {
+        return executeLoggingAbbreviatedBindVariables;
+    }
+
+    public void setExecuteLoggingAbbreviatedBindVariables(final Boolean executeLoggingAbbreviatedBindVariables) {
+        this.executeLoggingAbbreviatedBindVariables = executeLoggingAbbreviatedBindVariables;
+    }
+
+    public Log.Level getExecuteLoggingSqlString() {
+        return executeLoggingSqlString;
+    }
+
+    public void setExecuteLoggingSqlString(final Log.Level executeLoggingSqlString) {
+        this.executeLoggingSqlString = executeLoggingSqlString;
+    }
+
+    public Log.Level getExecuteLoggingResult() {
+        return executeLoggingResult;
+    }
+
+    public void setExecuteLoggingResult(final Log.Level executeLoggingResult) {
+        this.executeLoggingResult = executeLoggingResult;
+    }
+
+    public Integer getExecuteLoggingResultNumberOfRows() {
+        return executeLoggingResultNumberOfRows;
+    }
+
+    public void setExecuteLoggingResultNumberOfRows(final Integer executeLoggingResultNumberOfRows) {
+        this.executeLoggingResultNumberOfRows = executeLoggingResultNumberOfRows;
+    }
+
+    public Integer getExecuteLoggingResultNumberOfColumns() {
+        return executeLoggingResultNumberOfColumns;
+    }
+
+    public void setExecuteLoggingResultNumberOfColumns(final Integer executeLoggingResultNumberOfColumns) {
+        this.executeLoggingResultNumberOfColumns = executeLoggingResultNumberOfColumns;
+    }
+
+    public Log.Level getExecuteLoggingRoutine() {
+        return executeLoggingRoutine;
+    }
+
+    public void setExecuteLoggingRoutine(final Log.Level executeLoggingRoutine) {
+        this.executeLoggingRoutine = executeLoggingRoutine;
+    }
+
+    public Log.Level getExecuteLoggingException() {
+        return executeLoggingException;
+    }
+
+    public void setExecuteLoggingException(final Log.Level executeLoggingException) {
+        this.executeLoggingException = executeLoggingException;
     }
 
     /**
@@ -1084,6 +1166,55 @@ public class Settings
         return this;
     }
 
+    public Settings withExecuteLoggingBindVariables(Log.Level value) {
+        setExecuteLoggingBindVariables(value);
+        return this;
+    }
+
+    public Settings withExecuteLoggingAbbreviatedBindVariables(Boolean value) {
+        setExecuteLoggingAbbreviatedBindVariables(value);
+        return this;
+    }
+
+    public Settings withExecuteLoggingSqlString(Log.Level value) {
+        setExecuteLoggingSqlString(value);
+        return this;
+    }
+
+    public Settings withExecuteLoggingResult(Log.Level value) {
+        setExecuteLoggingResult(value);
+        return this;
+    }
+
+    public Settings withExecuteLoggingResultNumberOfRows(Integer value) {
+        setExecuteLoggingResultNumberOfRows(value);
+        return this;
+    }
+
+    public Settings withExecuteLoggingResultNumberOfColumns(Integer value) {
+        setExecuteLoggingResultNumberOfColumns(value);
+        return this;
+    }
+
+    public Settings withExecuteLoggingRoutine(Log.Level value) {
+        setExecuteLoggingRoutine(value);
+        return this;
+    }
+
+    public Settings withExecuteLoggingException(Log.Level value) {
+        setExecuteLoggingException(value);
+        return this;
+    }
+
+    public Settings withExecuteLoggingOverallLevel(Log.Level value) {
+        setExecuteLoggingBindVariables(value);
+        setExecuteLoggingSqlString(value);
+        setExecuteLoggingResult(value);
+        setExecuteLoggingRoutine(value);
+        setExecuteLoggingException(value);
+        return this;
+    }
+
     public Settings withExecuteWithOptimisticLocking(Boolean value) {
         setExecuteWithOptimisticLocking(value);
         return this;
@@ -1266,6 +1397,46 @@ public class Settings
             sb.append("<executeLogging>");
             sb.append(executeLogging);
             sb.append("</executeLogging>");
+        }
+        if (executeLoggingBindVariables!= null) {
+            sb.append("<executeLoggingBindVariables>");
+            sb.append(executeLoggingBindVariables);
+            sb.append("</executeLoggingBindVariables>");
+        }
+        if (executeLoggingAbbreviatedBindVariables!= null) {
+            sb.append("<executeLoggingAbbreviatedBindVariables>");
+            sb.append(executeLoggingAbbreviatedBindVariables);
+            sb.append("</executeLoggingAbbreviatedBindVariables>");
+        }
+        if (executeLoggingSqlString!= null) {
+            sb.append("<executeLoggingSqlString>");
+            sb.append(executeLoggingSqlString);
+            sb.append("</executeLoggingSqlString>");
+        }
+        if (executeLoggingResult!= null) {
+            sb.append("<executeLoggingResult>");
+            sb.append(executeLoggingResult);
+            sb.append("</executeLoggingResult>");
+        }
+        if (executeLoggingResultNumberOfRows!= null) {
+            sb.append("<executeLoggingResultNumberOfRows>");
+            sb.append(executeLoggingResultNumberOfRows);
+            sb.append("</executeLoggingResultNumberOfRows>");
+        }
+        if (executeLoggingResultNumberOfColumns!= null) {
+            sb.append("<executeLoggingResultNumberOfColumns>");
+            sb.append(executeLoggingResultNumberOfColumns);
+            sb.append("</executeLoggingResultNumberOfColumns>");
+        }
+        if (executeLoggingRoutine!= null) {
+            sb.append("<executeLoggingRoutine>");
+            sb.append(executeLoggingRoutine);
+            sb.append("</executeLoggingRoutine>");
+        }
+        if (executeLoggingException!= null) {
+            sb.append("<executeLoggingException>");
+            sb.append(executeLoggingException);
+            sb.append("</executeLoggingException>");
         }
         if (executeWithOptimisticLocking!= null) {
             sb.append("<executeWithOptimisticLocking>");
@@ -1514,6 +1685,78 @@ public class Settings
                 return false;
             }
         }
+        if (executeLoggingBindVariables == null) {
+            if (other.executeLoggingBindVariables!= null) {
+                return false;
+            }
+        } else {
+            if (!executeLoggingBindVariables.equals(other.executeLoggingBindVariables)) {
+                return false;
+            }
+        }
+        if (executeLoggingAbbreviatedBindVariables == null) {
+            if (other.executeLoggingAbbreviatedBindVariables!= null) {
+                return false;
+            }
+        } else {
+            if (!executeLoggingAbbreviatedBindVariables.equals(other.executeLoggingAbbreviatedBindVariables)) {
+                return false;
+            }
+        }
+        if (executeLoggingSqlString == null) {
+            if (other.executeLoggingSqlString!= null) {
+                return false;
+            }
+        } else {
+            if (!executeLoggingSqlString.equals(other.executeLoggingSqlString)) {
+                return false;
+            }
+        }
+        if (executeLoggingResult == null) {
+            if (other.executeLoggingResult!= null) {
+                return false;
+            }
+        } else {
+            if (!executeLoggingResult.equals(other.executeLoggingResult)) {
+                return false;
+            }
+        }
+        if (executeLoggingResultNumberOfRows == null) {
+            if (other.executeLoggingResultNumberOfRows!= null) {
+                return false;
+            }
+        } else {
+            if (!executeLoggingResultNumberOfRows.equals(other.executeLoggingResultNumberOfRows)) {
+                return false;
+            }
+        }
+        if (executeLoggingResultNumberOfColumns == null) {
+            if (other.executeLoggingResultNumberOfColumns!= null) {
+                return false;
+            }
+        } else {
+            if (!executeLoggingResultNumberOfColumns.equals(other.executeLoggingResultNumberOfColumns)) {
+                return false;
+            }
+        }
+        if (executeLoggingRoutine == null) {
+            if (other.executeLoggingRoutine!= null) {
+                return false;
+            }
+        } else {
+            if (!executeLoggingRoutine.equals(other.executeLoggingRoutine)) {
+                return false;
+            }
+        }
+        if (executeLoggingException == null) {
+            if (other.executeLoggingException!= null) {
+                return false;
+            }
+        } else {
+            if (!executeLoggingException.equals(other.executeLoggingException)) {
+                return false;
+            }
+        }
         if (executeWithOptimisticLocking == null) {
             if (other.executeWithOptimisticLocking!= null) {
                 return false;
@@ -1741,6 +1984,14 @@ public class Settings
         result = ((prime*result)+((paramCastMode == null)? 0 :paramCastMode.hashCode()));
         result = ((prime*result)+((statementType == null)? 0 :statementType.hashCode()));
         result = ((prime*result)+((executeLogging == null)? 0 :executeLogging.hashCode()));
+        result = ((prime*result)+((executeLoggingBindVariables == null)? 0 :executeLoggingBindVariables.hashCode()));
+        result = ((prime*result)+((executeLoggingAbbreviatedBindVariables == null)? 0 :executeLoggingAbbreviatedBindVariables.hashCode()));
+        result = ((prime*result)+((executeLoggingSqlString == null)? 0 :executeLoggingSqlString.hashCode()));
+        result = ((prime*result)+((executeLoggingResult == null)? 0 :executeLoggingResult.hashCode()));
+        result = ((prime*result)+((executeLoggingResultNumberOfRows == null)? 0 :executeLoggingResultNumberOfRows.hashCode()));
+        result = ((prime*result)+((executeLoggingResultNumberOfColumns == null)? 0 :executeLoggingResultNumberOfColumns.hashCode()));
+        result = ((prime*result)+((executeLoggingRoutine == null)? 0 :executeLoggingRoutine.hashCode()));
+        result = ((prime*result)+((executeLoggingException == null)? 0 :executeLoggingException.hashCode()));
         result = ((prime*result)+((executeWithOptimisticLocking == null)? 0 :executeWithOptimisticLocking.hashCode()));
         result = ((prime*result)+((executeWithOptimisticLockingExcludeUnversioned == null)? 0 :executeWithOptimisticLockingExcludeUnversioned.hashCode()));
         result = ((prime*result)+((attachRecords == null)? 0 :attachRecords.hashCode()));

--- a/jOOQ/src/main/java/org/jooq/impl/ExecuteListeners.java
+++ b/jOOQ/src/main/java/org/jooq/impl/ExecuteListeners.java
@@ -102,7 +102,15 @@ final class ExecuteListeners implements ExecuteListener {
             // [#6747] Avoid allocating the listener (and by consequence, the ExecuteListeners) if
             //         we do not DEBUG log anyway.
             if (LOGGER_LISTENER_LOGGER.isDebugEnabled())
-                (result = init(result)).add(new LoggerListener());
+                (result = init(result)).add(new LoggerListener(
+                        ctx.settings().getExecuteLoggingBindVariables(),
+                        ctx.settings().isExecuteLoggingAbbreviatedBindVariables(),
+                        ctx.settings().getExecuteLoggingSqlString(),
+                        ctx.settings().getExecuteLoggingResult(),
+                        ctx.settings().getExecuteLoggingResultNumberOfRows(),
+                        ctx.settings().getExecuteLoggingResultNumberOfColumns(),
+                        ctx.settings().getExecuteLoggingRoutine(),
+                        ctx.settings().getExecuteLoggingException()));
         }
 
         for (ExecuteListenerProvider provider : ctx.configuration().executeListenerProviders())

--- a/jOOQ/src/main/resources/META-INF/ABOUT.txt
+++ b/jOOQ/src/main/resources/META-INF/ABOUT.txt
@@ -18,6 +18,7 @@ Authors and contributors of jOOQ or parts of jOOQ in alphabetical order:
 - Fabrice Le Roy
 - Gonzalo Ortiz Jaureguizar
 - Gregory Hlavac
+- Grenville Wilson
 - Henrik Sjöstrand
 - Ivan Dugic
 - Javier Durante


### PR DESCRIPTION
Let me know what you think. Here's my random collection of questions/concerns/comments:

- The version of Log4J you're using doesn't have `isWarnEnabled()` or `isErrorEnabled()`. I used a method that takes a deprecated enum instead, which I'm not super happy about.
- Is there a reason Settings isn't using Object.equals and Object.hash? The custom implementation is kind of verbose.
- This doesn't let you log with an SFL4J marker. That's kind of tricky to pull off, since you also support Log4J and java.util.Logging. I guess let people set a marker in the Settings, then only use it if logging with SFL4J?
- I treat FATAL as ERROR. Let me know if that's okay.