### PR TITLE
Initialize data types when creating context

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/DefaultDSLContext.java
+++ b/jOOQ/src/main/java/org/jooq/impl/DefaultDSLContext.java
@@ -335,6 +335,9 @@ public class DefaultDSLContext extends AbstractScope implements DSLContext, Seri
 
     public DefaultDSLContext(Configuration configuration) {
         super(configuration, configuration == null ? null : configuration.data());
+        if (configuration != null) {
+            SQLDialectRegistry.initializeDialect(configuration.dialect());
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -4474,19 +4477,6 @@ public class DefaultDSLContext extends AbstractScope implements DSLContext, Seri
         DeleteQuery<R> delete = deleteQuery(record.getTable());
         delete.addConditions(condition);
         return delete.execute();
-    }
-
-    // -------------------------------------------------------------------------
-    // XXX Static initialisation of dialect-specific data types
-    // -------------------------------------------------------------------------
-
-    static {
-        // Load all dialect-specific data types
-        // TODO [#650] Make this more reliable using a data type registry
-
-        try {
-            Class.forName(SQLDataType.class.getName());
-        } catch (Exception ignore) {}
     }
 
     // -------------------------------------------------------------------------

--- a/jOOQ/src/main/java/org/jooq/impl/DefaultDataType.java
+++ b/jOOQ/src/main/java/org/jooq/impl/DefaultDataType.java
@@ -233,12 +233,6 @@ public class DefaultDataType<T> implements DataType<T> {
         }
 
         SQL_DATATYPES_BY_TYPE = new LinkedHashMap<Class<?>, DataType<?>>();
-
-        // [#2506] Transitively load all dialect-specific data types
-        try {
-            Class.forName(SQLDataType.class.getName());
-        }
-        catch (Exception ignore) {}
     }
 
     public DefaultDataType(SQLDialect dialect, DataType<T> sqlDataType, String typeName) {

--- a/jOOQ/src/main/java/org/jooq/impl/SQLDataType.java
+++ b/jOOQ/src/main/java/org/jooq/impl/SQLDataType.java
@@ -573,40 +573,6 @@ public final class SQLDataType {
      */
     public static final DataType<UUID> UUID = new DefaultDataType<UUID>(null, UUID.class, "uuid");
 
-    // -------------------------------------------------------------------------
-    // Static initialisation of dialect-specific data types
-    // -------------------------------------------------------------------------
-
-    static {
-        // Load all dialect-specific data types
-        // TODO [#650] Make this more reliable using a data type registry
-
-        try {
-
-
-
-
-
-
-
-
-
-
-
-
-
-            Class.forName(CUBRIDDataType.class.getName());
-            Class.forName(DerbyDataType.class.getName());
-            Class.forName(FirebirdDataType.class.getName());
-            Class.forName(H2DataType.class.getName());
-            Class.forName(HSQLDBDataType.class.getName());
-            Class.forName(MariaDBDataType.class.getName());
-            Class.forName(MySQLDataType.class.getName());
-            Class.forName(PostgresDataType.class.getName());
-            Class.forName(SQLiteDataType.class.getName());
-        } catch (Exception ignore) {}
-    }
-
     /**
      * No instances
      */

--- a/jOOQ/src/main/java/org/jooq/impl/SQLDialectRegistry.java
+++ b/jOOQ/src/main/java/org/jooq/impl/SQLDialectRegistry.java
@@ -1,0 +1,41 @@
+package org.jooq.impl;
+
+import org.jooq.SQLDialect;
+import org.jooq.util.cubrid.CUBRIDDataType;
+import org.jooq.util.firebird.FirebirdDataType;
+import org.jooq.util.h2.H2DataType;
+import org.jooq.util.hsqldb.HSQLDBDataType;
+import org.jooq.util.mariadb.MariaDBDataType;
+import org.jooq.util.mysql.MySQLDataType;
+import org.jooq.util.postgres.PostgresDataType;
+import org.jooq.util.sqlite.SQLiteDataType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class SQLDialectRegistry {
+
+    private static Map<SQLDialect, Class<?>> dataTypeClasses = new HashMap<>();
+
+    static {
+        dataTypeClasses.put(SQLDialect.SQL99, SQLDataType.class);
+        dataTypeClasses.put(SQLDialect.DEFAULT, SQLDataType.class);
+        dataTypeClasses.put(SQLDialect.CUBRID, CUBRIDDataType.class);
+        dataTypeClasses.put(SQLDialect.FIREBIRD, FirebirdDataType.class);
+        dataTypeClasses.put(SQLDialect.H2, H2DataType.class);
+        dataTypeClasses.put(SQLDialect.HSQLDB, HSQLDBDataType.class);
+        dataTypeClasses.put(SQLDialect.MARIADB, MariaDBDataType.class);
+        dataTypeClasses.put(SQLDialect.MYSQL, MySQLDataType.class);
+        dataTypeClasses.put(SQLDialect.POSTGRES, PostgresDataType.class);
+        dataTypeClasses.put(SQLDialect.SQLITE, SQLiteDataType.class);
+    }
+
+    static void initializeDialect(SQLDialect dialect) {
+        Class<?> dataTypeClass = dataTypeClasses.get(dialect.family());
+        try {
+            Class.forName(dataTypeClass.getName());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Revised version of #7350 , this time without touching the `SQLDialect` enum.
Hope this time it does not look "hacky" 😄 