### PR TITLE
Make SQLQuery public

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/SQLQuery.java
+++ b/jOOQ/src/main/java/org/jooq/impl/SQLQuery.java
@@ -46,7 +46,7 @@ import org.jooq.QueryPartInternal;
 /**
  * @author Lukas Eder
  */
-final class SQLQuery extends AbstractQuery {
+public final class SQLQuery extends AbstractQuery {
 
     /**
      * Generated UID


### PR DESCRIPTION
Hi Lukas,

looking at your ["Custom Logging ExecuteListener" example](https://www.jooq.org/doc/3.10/manual/sql-execution/execute-listeners/#N49B2E) I am not sure if that is still working as supposed. Look at the `if/else`:

```java
        // If we're executing a query
        if (ctx.query() != null) {
            System.out.println(create.renderInlined(ctx.query()));
        }
        
        // If we're executing a routine
        else if (ctx.routine() != null) {
            System.out.println(create.renderInlined(ctx.routine()));
        }
        
        // If we're executing anything else (e.g. plain SQL)
        else if (!StringUtils.isBlank(ctx.sql())) {
            // ==> @lukaseder: I was never able to execute that if branch
            System.out.println(ctx.sql());
        }
```
I wasn't able to ever execute the last "plain SQL" if branch. I don't know how to get there, because when I run `create.execute("some sql")` or `create.execute(DSL.sql("some sql"))` I already always run in the first `if` branch because we actually end up with a query of type `org.jooq.impl.SQLQuery`.

That is why I propose to make the `SQLQuery` class public, so we can check if the `ctx.query()` is an instance of that type. That is actually what you do in your `NoInsertListener` [example](https://www.jooq.org/doc/3.10/manual/sql-building/dsl-context/custom-data/), you check for `ctx.query() instanceof Insert`, however right now it's not possible to check that for plain sql.

So the point is we want to be able to check if a query was a plain sql query.