### PR TITLE
Spring boot example test repeats identical assertion

### DIFF
--- a/jOOQ-examples/jOOQ-spring-boot-example/src/test/java/org/jooq/example/spring/TransactionTest.java
+++ b/jOOQ-examples/jOOQ-spring-boot-example/src/test/java/org/jooq/example/spring/TransactionTest.java
@@ -154,7 +154,7 @@ public class TransactionTest {
 		}
 
 		assertEquals(4, dsl.fetchCount(BOOK));
-		assertTrue(rollback2.get());
+		assertTrue(rollback1.get());
 		assertTrue(rollback2.get());
 	}
 }


### PR DESCRIPTION
I guess it should assert rollback1 and rollback2 instead.