### PR TITLE
Upgrade to maven-compiler-plugin 3.7.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,13 @@
         </dependencies>
     </dependencyManagement>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>apache.snapshots</id>
+            <url>http://repository.apache.org/snapshots/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <build>
         <finalName>${project.artifactId}-${project.version}</finalName>
         <pluginManagement>
@@ -181,7 +188,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.7.0</version>
+                    <version>3.7.1-SNAPSHOT</version>
 
                     <configuration>
                         <!-- When compilers say false, they mean true ...


### PR DESCRIPTION
Prior to this commit, the `maven-compiler-plugin` **3.7.0** places jars on the class path which need to be placed on the module path. See errors at https://travis-ci.org/jOOQ/jOOQ/builds/400924646#L2003

Using `maven-compiler-plugin` **3.7.1-SNAPSHOT** solves this issue.

Related bug: https://issues.apache.org/jira/browse/MCOMPILER-336