### PR TITLE
Added support for additional postgresql 9.3+ locking modes

### DIFF
--- a/jOOQ/src/main/java/org/jooq/SelectForShareKeyStep.java
+++ b/jOOQ/src/main/java/org/jooq/SelectForShareKeyStep.java
@@ -1,0 +1,10 @@
+package org.jooq;
+
+import static org.jooq.SQLDialect.POSTGRES_9_3;
+
+public interface SelectForShareKeyStep<R extends Record> extends SelectOptionStep<R> {
+
+    @Support({ POSTGRES_9_3 })
+    SelectOptionStep<R> key();
+
+}

--- a/jOOQ/src/main/java/org/jooq/SelectForUpdateNoKeyStep.java
+++ b/jOOQ/src/main/java/org/jooq/SelectForUpdateNoKeyStep.java
@@ -1,0 +1,17 @@
+package org.jooq;
+
+import static org.jooq.SQLDialect.POSTGRES_9_3;
+
+public interface SelectForUpdateNoKeyStep<R extends Record> extends SelectOptionStep<R> {
+
+    /**
+     * Add a <code>NO KEY</code> clause to the <code>FOR UPDATE</code> clause at
+     * the end of the query.
+     *
+     * @see SelectQuery#setForUpdateSkipLocked() see LockProvider for more
+     *      details
+     */
+    @Support({ POSTGRES_9_3 })
+    SelectForUpdateWaitStep<R> noKey();
+
+}

--- a/jOOQ/src/main/java/org/jooq/SelectForUpdateStep.java
+++ b/jOOQ/src/main/java/org/jooq/SelectForUpdateStep.java
@@ -140,7 +140,7 @@ public interface SelectForUpdateStep<R extends Record> extends SelectOptionStep<
      *      details
      */
     @Support({ MARIADB, MYSQL, POSTGRES })
-    SelectOptionStep<R> forShare();
+    SelectForShareKeyStep<R> forShare();
 
 
 

--- a/jOOQ/src/main/java/org/jooq/SelectForUpdateWaitStep.java
+++ b/jOOQ/src/main/java/org/jooq/SelectForUpdateWaitStep.java
@@ -103,7 +103,7 @@ import static org.jooq.SQLDialect.POSTGRES_9_5;
  *
  * @author Lukas Eder
  */
-public interface SelectForUpdateWaitStep<R extends Record> extends SelectOptionStep<R> {
+public interface SelectForUpdateWaitStep<R extends Record> extends SelectForUpdateNoKeyStep<R> {
 
 
 

--- a/jOOQ/src/main/java/org/jooq/SelectQuery.java
+++ b/jOOQ/src/main/java/org/jooq/SelectQuery.java
@@ -57,6 +57,7 @@ import static org.jooq.SQLDialect.MYSQL_8_0;
 // ...
 // ...
 import static org.jooq.SQLDialect.POSTGRES;
+import static org.jooq.SQLDialect.POSTGRES_9_3;
 import static org.jooq.SQLDialect.POSTGRES_9_5;
 // ...
 // ...
@@ -872,6 +873,22 @@ public interface SelectQuery<R extends Record> extends Select<R>, ConditionProvi
     void setForUpdate(boolean forUpdate);
 
     /**
+     * Some RDBMS allow for specifying the locking mode for the applied
+     * <code>FOR UPDATE</code> clause. In this case, the session will disallow updates to the primary key, avoiding
+     * locking of inserts and updates on foreign keys to record primary key values.
+     * <p>
+     * This automatically sets the {@link #setForUpdate(boolean)} flag, and
+     * unsets the {@link #setForShare(boolean)} flag, if it was previously set.
+     * <p>
+     * This has been observed to be supported by any of these dialects:
+     * <ul>
+     * <li>Postgres 9.3+</li>
+     * </ul>
+     */
+    @Support({ POSTGRES_9_3 })
+    void setForNoKeyUpdate(boolean forNoKeyUpdate);
+
+    /**
      * Some RDBMS allow for specifying the fields that should be locked by the
      * <code>FOR UPDATE</code> clause, instead of the full row.
      * <p>
@@ -1013,6 +1030,22 @@ public interface SelectQuery<R extends Record> extends Select<R>, ConditionProvi
      */
     @Support({ MARIADB, MYSQL, POSTGRES })
     void setForShare(boolean forShare);
+
+    /**
+     * Some RDBMS allow for specifying the locking mode for the applied
+     * <code>FOR SHARE</code> clause. In this case, the share can be acquired on a row with an
+     * existing for no key update lock.
+     * <p>
+     * This automatically sets the {@link #setForShare(boolean)} flag, and
+     * unsets the {@link #setForUpdate(boolean)} flag, if it was previously set.
+     * <p>
+     * This has been observed to be supported by any of these dialects:
+     * <ul>
+     * <li>Postgres 9.3+</li>
+     * </ul>
+     */
+    @Support({ POSTGRES_9_3 })
+    void setForKeyShare(boolean forKeyShare);
 
 
 

--- a/jOOQ/src/main/java/org/jooq/impl/Keywords.java
+++ b/jOOQ/src/main/java/org/jooq/impl/Keywords.java
@@ -139,6 +139,8 @@ final class Keywords {
     static final Keyword K_FOR                              = keyword("for");
     static final Keyword K_FORALL                           = keyword("forall");
     static final Keyword K_FORMAT                           = keyword("format");
+    static final Keyword K_FOR_NO_KEY_UPDATE                = keyword("for no key update");
+    static final Keyword K_FOR_KEY_SHARE                    = keyword("for key share");
     static final Keyword K_FOR_SHARE                        = keyword("for share");
     static final Keyword K_FOR_UPDATE                       = keyword("for update");
     static final Keyword K_FOREIGN_KEY                      = keyword("foreign key");

--- a/jOOQ/src/main/java/org/jooq/impl/SelectImpl.java
+++ b/jOOQ/src/main/java/org/jooq/impl/SelectImpl.java
@@ -88,6 +88,7 @@ import org.jooq.SelectConnectByAfterStartWithStep;
 import org.jooq.SelectConnectByConditionStep;
 import org.jooq.SelectFieldOrAsterisk;
 import org.jooq.SelectFinalStep;
+import org.jooq.SelectForShareKeyStep;
 import org.jooq.SelectForUpdateOfStep;
 import org.jooq.SelectHavingConditionStep;
 import org.jooq.SelectIntoStep;
@@ -176,7 +177,8 @@ final class SelectImpl<R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     SelectLimitPercentStep<R>,
     SelectLimitAfterOffsetStep<R>,
     SelectLimitPercentAfterOffsetStep<R>,
-    SelectForUpdateOfStep<R> {
+    SelectForUpdateOfStep<R>,
+    SelectForShareKeyStep<R> {
 
     /**
      * Generated UID
@@ -1773,8 +1775,20 @@ final class SelectImpl<R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     }
 
     @Override
+    public final SelectImpl noKey() {
+        getQuery().setForNoKeyUpdate(true);
+        return this;
+    }
+
+    @Override
     public final SelectImpl forShare() {
         getQuery().setForShare(true);
+        return this;
+    }
+
+    @Override
+    public final SelectImpl key() {
+        getQuery().setForKeyShare(true);
         return this;
     }
 


### PR DESCRIPTION
Implemented postgresql 9.3+ SELECT FOR NO KEY UPDATE support via forUpdate().noKey().
Implemented postgresql 9.3+ SELECT FOR KEY SHARE support via forShare().key().

My team had some issues with Postgres's FOR UPDATE locking inserts and updates on foreign key rows due to the possibility of a "FOR UPDATE" updating the primary key.

SELECT FOR NO KEY UPDATE is Postgres's slightly less pessimistic locking mode to prevent this.

Likewise, SELECT FOR KEY SHARE allows FOR SHARE semantics on a row locked by "FOR NO KEY UPDATE".

Figured I'd just take a shot at implementing this and sending a PR.