### PR TITLE
In Coerce use the qualified name so that fields can be compared again

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/Coerce.java
+++ b/jOOQ/src/main/java/org/jooq/impl/Coerce.java
@@ -54,7 +54,7 @@ final class Coerce<T> extends AbstractField<T> {
     private final Field<?>    field;
 
     public Coerce(Field<?> field, DataType<T> type) {
-        super(field.getUnqualifiedName(), type);
+        super(field.getQualifiedName(), type);
 
         this.field = (field instanceof Coerce) ? ((Coerce<?>) field).field : field;
     }


### PR DESCRIPTION
The Coerce'ed field renders the full qualified name in SQL, but the field-name is used for comparison, so the name should match the rendered SQL.

After updating to jOOQ 3.11.4 some of our query creation code fails as it compares Coerce'ed table fields and they are not equal anymore (as they where before). With the proposed change the code works again as expected.