### PR TITLE
Fix Javadoc entry for Field#containsIgnoreCase

### DIFF
--- a/jOOQ/src/main/java/org/jooq/Field.java
+++ b/jOOQ/src/main/java/org/jooq/Field.java
@@ -1676,9 +1676,9 @@ extends
      * proper adding of wildcards and escaping.
      * <p>
      * This translates to
-     * <code>this not ilike ('%' || escape(value, '\') || '%') escape '\'</code>
+     * <code>this ilike ('%' || escape(value, '\') || '%') escape '\'</code>
      * in {@link SQLDialect#POSTGRES}, or to
-     * <code>lower(this) not like lower(('%' || escape(value, '\') || '%') escape '\')</code>
+     * <code>lower(this) like lower(('%' || escape(value, '\') || '%') escape '\')</code>
      * in all other dialects.
      * </p>
      *


### PR DESCRIPTION
This fixes #7938.

---

The SQL-equivalent part of this method's documentation was wrongly indicating that it:
> translates to `this not ilike` ... in POSTGRES, or to `lower(this) not like lower` ... in all other dialects.

---

I removed the `not`.

Could not find any other similar mistake – I'm pretty sure that was an isolated case.