### PR TITLE
[#8004] Handle edgecase for Kotlin boolean type

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/DefaultRecordMapper.java
+++ b/jOOQ/src/main/java/org/jooq/impl/DefaultRecordMapper.java
@@ -402,7 +402,9 @@ public class DefaultRecordMapper<R extends Record, E> implements RecordMapper<R,
 
                     for (int i = 0; i < parameterTypes.length; i++) {
                         Reflect parameter = Reflect.on(parameters.get(i));
-                        parameterNames.add(parameter.call("getName").<String>get());
+                        // [#8004] Clean up kotlin field name for boolean types
+                        String name = parameter.call("getName").<String>get();
+                        parameterNames.add(getPropertyName(name));
                         Object typeClassifier = parameter.call("getType").call("getClassifier").get();
                         parameterTypes[i] = (Class<?>) getJavaClass.invoke(jvmClassMappingKt.get(), typeClassifier);
                     }

--- a/jOOQ/src/main/java/org/jooq/impl/DefaultRecordMapper.java
+++ b/jOOQ/src/main/java/org/jooq/impl/DefaultRecordMapper.java
@@ -408,7 +408,7 @@ public class DefaultRecordMapper<R extends Record, E> implements RecordMapper<R,
                         String name = parameter.call("getName").<String>get();
 
                         // [#8004] Clean up kotlin field name for boolean types
-                        if ("boolean".equals(type.getTypeName()) && name.startsWith("is")) {
+                        if ("boolean".equalsIgnoreCase(type.getTypeName()) && name.startsWith("is")) {
                             name = getPropertyName(name);
                         }
                         parameterNames.add(name);

--- a/jOOQ/src/main/java/org/jooq/impl/DefaultRecordMapper.java
+++ b/jOOQ/src/main/java/org/jooq/impl/DefaultRecordMapper.java
@@ -402,11 +402,16 @@ public class DefaultRecordMapper<R extends Record, E> implements RecordMapper<R,
 
                     for (int i = 0; i < parameterTypes.length; i++) {
                         Reflect parameter = Reflect.on(parameters.get(i));
-                        // [#8004] Clean up kotlin field name for boolean types
-                        String name = parameter.call("getName").<String>get();
-                        parameterNames.add(getPropertyName(name));
                         Object typeClassifier = parameter.call("getType").call("getClassifier").get();
-                        parameterTypes[i] = (Class<?>) getJavaClass.invoke(jvmClassMappingKt.get(), typeClassifier);
+                        Class<?> type = (Class<?>) getJavaClass.invoke(jvmClassMappingKt.get(), typeClassifier);
+                        parameterTypes[i] = type;
+                        String name = parameter.call("getName").<String>get();
+
+                        // [#8004] Clean up kotlin field name for boolean types
+                        if ("boolean".equals(type.getTypeName()) && name.startsWith("is")) {
+                            name = getPropertyName(name);
+                        }
+                        parameterNames.add(name);
                     }
 
                     Constructor<E> javaConstructor = (Constructor<E>) this.type.getConstructor(parameterTypes);


### PR DESCRIPTION
Fixes: #8004

trim Kotlin property names to handle edgecase for booleans