### PR TITLE
Add "overrides" to @SuppressWarnings class annotations. Fixes compile…

### DIFF
--- a/jOOQ-codegen/src/main/java/org/jooq/codegen/JavaGenerator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/codegen/JavaGenerator.java
@@ -5822,7 +5822,7 @@ public class JavaGenerator extends AbstractGenerator {
         }
 
         if (!scala)
-            out.println("@%s({ \"all\", \"unchecked\", \"rawtypes\" })", out.ref("java.lang.SuppressWarnings"));
+            out.println("@%s({ \"all\", \"unchecked\", \"rawtypes\", \"overrides\" })", out.ref("java.lang.SuppressWarnings"));
     }
 
     private String readVersion(File file, String type) {


### PR DESCRIPTION
This fixes a problem we encountered recently when trying to enable strict javac flags on one of my builds.

Database is postgres and some tables have array columns.

```
    /**
     * Set the first value.
     */
    Record1<T1> value1(T1 value);
```

gets overridden with

```
    /**
     * {@inheritDoc}
     */
    @Override
    public FooRecord value1(String... value) {
        setFooArray(value);
        return this;
    }
```

which leads to a ```overridden method has no '...' ``` 
compiler warning.

compiler options are
`def javacOptions = [ "-Xlint:all" , "-Xlint:-processing", "-Werror" ]`
