### PR TITLE
Make ConvertAll.from static to avoid pointless allocations, partially addresses #6799

### DIFF
--- a/jOOQ/src/main/java/org/jooq/tools/Convert.java
+++ b/jOOQ/src/main/java/org/jooq/tools/Convert.java
@@ -380,7 +380,7 @@ public final class Convert {
      * @throws DataTypeException - When the conversion is not possible
      */
     public static final <T> T convert(Object from, Class<? extends T> toClass) throws DataTypeException {
-        return ConvertAll.from(ConvertAll.from(from, toClass), toClass);
+        return ConvertAll.from(from, toClass);
     }
 
     /**
@@ -424,7 +424,7 @@ public final class Convert {
         List<U> result = new ArrayList<U>(collection.size());
 
         for (Object o : collection) {
-            result.add(convert(ConvertAll.from(o, converter.fromType()), converter));
+            result.add(convert(o, converter));
         }
 
         return result;


### PR DESCRIPTION
I've got this as 2 commits currently as this change reveals some apparently unnecessary invocations of the conversion routine, but I can't be sure that they're definitely unnecessary without running the test suite to check their removal wouldn't be a breaking change.

I could also now completely dissolve the ConvertAll class into the outer Convert class, but I've erred on the side of making fewer changes rather than more for now, so I'll leave it up to you