### PR TITLE
Sakila/PostgreSQL: Replace nonexisting IF with CASE

### DIFF
--- a/jOOQ-examples/Sakila/postgres-sakila-db/postgres-sakila-schema.sql
+++ b/jOOQ-examples/Sakila/postgres-sakila-db/postgres-sakila-schema.sql
@@ -684,8 +684,9 @@ BEGIN
       AND rental.rental_date <= p_effective_date
       AND rental.customer_id = p_customer_id;
 
-    SELECT COALESCE(SUM(IF((rental.return_date - rental.rental_date) > (film.rental_duration * '1 day'::interval),
-        ((rental.return_date - rental.rental_date) - (film.rental_duration * '1 day'::interval)),0)),0) INTO v_overfees
+    SELECT COALESCE(SUM(CASE WHEN (rental.return_date - rental.rental_date) > (film.rental_duration * '1 day'::interval)
+        THEN EXTRACT(DAY FROM (rental.return_date - rental.rental_date) - (film.rental_duration * '1 day'::interval))::integer
+        ELSE 0 END),0) INTO v_overfees
     FROM rental, inventory, film
     WHERE film.film_id = inventory.film_id
       AND inventory.inventory_id = rental.inventory_id


### PR DESCRIPTION
Function `get_customer_balance` declared in postgres_sakila_schema.sql uses a function called IF that doesn't exist in PostgreSQL (probably a remnant from the original MySQL version).
Replace the IF with a corresponding CASE statement, including appropriate conversions for the intervals.