### PR TITLE
[#9019] MySQL supports DROP TEMPORARY tables and recommends to use it

### DIFF
--- a/jOOQ/src/main/java/org/jooq/DSLContext.java
+++ b/jOOQ/src/main/java/org/jooq/DSLContext.java
@@ -9660,7 +9660,7 @@ public interface DSLContext extends Scope , AutoCloseable  {
      *
      * @see DSL#dropTemporaryTable(String)
      */
-    @Support
+    @Support({ MYSQL })
     DropTableStep dropTemporaryTable(String table);
 
     /**
@@ -9668,7 +9668,7 @@ public interface DSLContext extends Scope , AutoCloseable  {
      *
      * @see DSL#dropTemporaryTable(Name)
      */
-    @Support
+    @Support({ MYSQL })
     DropTableStep dropTemporaryTable(Name table);
 
     /**

--- a/jOOQ/src/main/java/org/jooq/impl/DefaultDSLContext.java
+++ b/jOOQ/src/main/java/org/jooq/impl/DefaultDSLContext.java
@@ -3522,17 +3522,17 @@ public class DefaultDSLContext extends AbstractScope implements DSLContext, Seri
 
     @Override
     public DropTableStep dropTemporaryTable(String table) {
-        return dropTable(name(table));
+        return dropTemporaryTable(name(table));
     }
 
     @Override
     public DropTableStep dropTemporaryTable(Name table) {
-        return dropTable(table(table));
+        return dropTemporaryTable(table(table));
     }
 
     @Override
     public DropTableStep dropTemporaryTable(Table<?> table) {
-        return new DropTableImpl(configuration(), table);
+        return new DropTableImpl(configuration(), table, false, true);
     }
 
     @Override

--- a/jOOQ/src/main/resources/META-INF/ABOUT.txt
+++ b/jOOQ/src/main/resources/META-INF/ABOUT.txt
@@ -2,6 +2,7 @@ Authors and contributors of jOOQ or parts of jOOQ in alphabetical order:
 ------------------------------------------------------------------------
 - Aaron Digulla
 - Andreas Franzén
+- Anton Kot
 - Anuraag Agrawal
 - Arnaud Roger
 - Art O Cathain


### PR DESCRIPTION
It should work. But soon there's no tests in the repo, could you give me idea how to check it's actually adding TEMPORARY kewword for MySQL? Thank you.