### PR TITLE
Support INSERT...RETURNING and DELETE...RETURNING with MariaDB

### DIFF
--- a/jOOQ/src/main/java/org/jooq/DeleteReturningStep.java
+++ b/jOOQ/src/main/java/org/jooq/DeleteReturningStep.java
@@ -41,6 +41,7 @@ package org.jooq;
 // ...
 import static org.jooq.SQLDialect.FIREBIRD;
 // ...
+import static org.jooq.SQLDialect.MARIADB;
 import static org.jooq.SQLDialect.POSTGRES;
 // ...
 
@@ -113,7 +114,7 @@ public interface DeleteReturningStep<R extends Record> extends DeleteFinalStep<R
      * @param fields Fields to be returned
      * @see DeleteResultStep
      */
-    @Support({ FIREBIRD, POSTGRES })
+    @Support({ MARIADB, FIREBIRD, POSTGRES })
     DeleteResultStep<R> returning(SelectFieldOrAsterisk... fields);
 
     /**


### PR DESCRIPTION
MariaDB support INSERT...RETURNING since [10.5.1](https://mariadb.com/kb/en/library/mariadb-1051-release-notes/) and DELETE...RETURNING since [10.0.5](https://mariadb.com/kb/en/library/mariadb-1005-release-notes/) !
Adding support for those features would be great.

I'm not sure how to deal with backwards compatibility. Should we add some config flags? or check if the server version support those features? or something else?