### PR TITLE
optimization: if no queries to execute in batch, nothing to do

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/BatchMultiple.java
+++ b/jOOQ/src/main/java/org/jooq/impl/BatchMultiple.java
@@ -77,6 +77,9 @@ final class BatchMultiple implements Batch {
     }
 
     static int[] execute(final Configuration configuration, final Query[] queries) {
+        if (queries.length == 0) {
+            return new int[0];
+        }
         ExecuteContext ctx = new DefaultExecuteContext(configuration, queries);
         ExecuteListener listener = ExecuteListeners.get(ctx);
         Connection connection = ctx.connection();


### PR DESCRIPTION
This case happened for a javamelody user: https://github.com/javamelody/javamelody/issues/863
Finding how it can happen lead me to suggest this PR.