### PR TITLE
[#9055] should NO table qualify if NO table alias

### DIFF
--- a/jOOQ/src/main/java/org/jooq/conf/Settings.java
+++ b/jOOQ/src/main/java/org/jooq/conf/Settings.java
@@ -41,6 +41,8 @@ public class Settings
     protected Boolean renderCatalog = true;
     @XmlElement(defaultValue = "true")
     protected Boolean renderSchema = true;
+    @XmlElement(defaultValue = "true")
+    protected Boolean renderTable = true;
     protected RenderMapping renderMapping;
     @XmlElement(defaultValue = "EXPLICIT_DEFAULT_QUOTED")
     @XmlSchemaType(name = "string")
@@ -251,6 +253,38 @@ public class Settings
      */
     public void setRenderSchema(Boolean value) {
         this.renderSchema = value;
+    }
+
+    /**
+     * Whether any Filed's table name should be rendered at all.
+     * BUT using table alias will always be rendered.
+     * <li> true:  SELECT table.f1, table.f2 FROM table
+     * <li> true:  SELECT t.f1, t.f2 FROM table as t
+     * <li> false: SELECT f1, f2 FROM table
+     * <li> false: SELECT t.f1, t.f2 FROM table as t
+     * <p>
+     * Use this for sharding case. eg. table (`TABLE_##`) name replacing ,
+     * or when all objects are made available using synonyms
+     *
+     * @return
+     *     possible object is
+     *     {@link Boolean }
+     *
+     */
+    public Boolean isRenderTable() {
+        return renderTable;
+    }
+
+    /**
+     * Sets the value of the renderTable property.
+     *
+     * @param value
+     *     allowed object is
+     *     {@link Boolean }
+     *
+     */
+    public void setRenderTable(Boolean value) {
+        this.renderTable = value;
     }
 
     /**
@@ -1904,6 +1938,11 @@ public class Settings
 
     public Settings withRenderSchema(Boolean value) {
         setRenderSchema(value);
+        return this;
+    }
+
+    public Settings withRenderTable(Boolean value) {
+        setRenderTable(value);
         return this;
     }
 

--- a/jOOQ/src/main/java/org/jooq/impl/TableFieldImpl.java
+++ b/jOOQ/src/main/java/org/jooq/impl/TableFieldImpl.java
@@ -89,7 +89,10 @@ final class TableFieldImpl<R extends Record, T> extends AbstractField<T> impleme
     public final void accept(Context<?> ctx) {
         ctx.data(DATA_OMIT_CLAUSE_EVENT_EMISSION, true);
 
-        if (ctx.qualify()) {
+        if (ctx.qualify()
+            // [#9055] should NO table qualify if NO table alias
+            && (ctx.settings().isRenderTable() || table instanceof TableImpl && ((TableImpl) table).alias != null)
+        ) {
             ctx.visit(table);
             ctx.sql('.');
         }


### PR DESCRIPTION
hi @lukaseder , 
I PR again, with `withRenderTable(false)` setting.
`renderTable` with default value `true` affects nothing.
when  renderTable is false, it only affects non-aliased table' field.

| renderTable | dsl.getSQL                            | affects |
|-------|---------------------------------------|---------|
| true(default)  | SELECT table.f1, table.f2 FROM table  | nothing   |
| true(default)  | SELECT t.f1, t.f2 FROM table **as** t     | nothing   |
| false | SELECT t.f1, t.f2 FROM table **as** t     | nothing   |
| false | SELECT f1, f2 FROM table              |  **NOT qulify table name**    |

this PR is most important in sharding scenario,
because the `table` will be replaced to `table_##`, 
the table qualified field may goes wrong.

thanks.