### PR TITLE
Update dependency coordinates for Jakarta EE

### DIFF
--- a/jOOQ-examples/jOOQ-jpa-example-entities/pom.xml
+++ b/jOOQ-examples/jOOQ-jpa-example-entities/pom.xml
@@ -64,18 +64,18 @@
                             <version>${org.hibernate.version}</version>
                         </annotationProcessorPath>
                         <annotationProcessorPath>
-                            <groupId>javax.xml.bind</groupId>
-                            <artifactId>jaxb-api</artifactId>
-                            <version>2.3.1</version>
+                            <groupId>jakarta.xml.bind</groupId>
+                            <artifactId>jakarta.xml.bind-api</artifactId>
+                            <version>2.3.2</version>
                         </annotationProcessorPath>
                     </annotationProcessorPaths>
                 </configuration>
 
                 <dependencies>
                     <dependency>
-                        <groupId>javax.xml.bind</groupId>
-                        <artifactId>jaxb-api</artifactId>
-                        <version>2.3.1</version>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>2.3.2</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/jOOQ-examples/jOOQ-jpa-example/pom.xml
+++ b/jOOQ-examples/jOOQ-jpa-example/pom.xml
@@ -39,9 +39,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
-            <version>2.2</version>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>2.2.3</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
@@ -164,9 +164,9 @@
                         <version>${project.version}</version>
                     </dependency>
                     <dependency>
-                        <groupId>javax.persistence</groupId>
-                        <artifactId>javax.persistence-api</artifactId>
-                        <version>2.2</version>
+                        <groupId>jakarta.persistence</groupId>
+                        <artifactId>jakarta.persistence-api</artifactId>
+                        <version>2.2.3</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/jOOQ-meta-extensions/pom.xml
+++ b/jOOQ-meta-extensions/pom.xml
@@ -53,8 +53,8 @@
             <artifactId>h2</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/jOOQ/pom.xml
+++ b/jOOQ/pom.xml
@@ -88,16 +88,16 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
         </dependency>
 
         <!-- From JDK 9 onwards, the JAXB dependency needs to be made explicit -->
         <!-- The dependency can cause trouble in older JDKs, so it needs to be
              excluded from pre-java-9 builds: https://github.com/jOOQ/jOOQ/issues/7649 -->
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,11 @@
         <hsqldb.version>2.5.0</hsqldb.version>
 
         <!-- From JDK 11 onwards, we need to depend on the JAXB API explicitly -->
-        <jaxb.version>2.3.1</jaxb.version>
-        <javax.activation.version>1.2.0</javax.activation.version>
+        <jakarta.xml.bind-api.version>2.3.2</jakarta.xml.bind-api.version>
+        <jakarta.activation-api.version>1.2.1</jakarta.activation-api.version>
 
         <!-- DefaultRecordMapper and jOOQ-meta-extensions can read JPA annotations -->
-        <javax.persistence-api.version>2.2</javax.persistence-api.version>
+        <jakarta.persistence-api.version>2.2.3</jakarta.persistence-api.version>
     </properties>
 
     <licenses>
@@ -121,9 +121,9 @@
             <!-- The dependency can cause trouble in older JDKs, so it needs to be
                  excluded from pre-java-9 builds: https://github.com/jOOQ/jOOQ/issues/7649 -->
             <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>${jaxb.version}</version>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>${jakarta.xml.bind-api.version}</version>
             </dependency>
 
 
@@ -176,9 +176,9 @@
 
             <!-- Optional JPA dependency -->
             <dependency>
-                <groupId>javax.persistence</groupId>
-                <artifactId>javax.persistence-api</artifactId>
-                <version>${javax.persistence-api.version}</version>
+                <groupId>jakarta.persistence</groupId>
+                <artifactId>jakarta.persistence-api</artifactId>
+                <version>${jakarta.persistence-api.version}</version>
                 <scope>provided</scope>
                 <optional>true</optional>
             </dependency>


### PR DESCRIPTION
Ahoy, this PR updates the various javax dependency coordinates to their new homes under jakarta.

Didn't see the `activation-api` dependency anywhere so I'm assuming it's in the jooq enterprise code, it will require an adjustment too.

AFAIK no breaking stuff has been done with these APIs yet, and so far my projects have also been fine having a mix of the old and new ones, so here's to hoping that your secret tests will pass this PR :)