### PR TITLE
Fixes #9670 to make jooq OSGi backwards compatible for slf4j and also…

### DIFF
--- a/jOOQ/pom.xml
+++ b/jOOQ/pom.xml
@@ -50,8 +50,11 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>*</Export-Package>
+                        <!-- do not import jooq (ourselves) -->
                         <Import-Package>
                             javax.persistence;resolution:=optional,
+                            org.slf4j;resolution:=optional;version="[1.7,2)",
+                            !org.jooq.*,
                             *
                         </Import-Package>
                         <_versionpolicy>[$(version;==;$(@)),$(version;+;$(@)))</_versionpolicy>

--- a/jOOQ/pom.xml
+++ b/jOOQ/pom.xml
@@ -50,11 +50,9 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>*</Export-Package>
-                        <!-- do not import jooq (ourselves) -->
                         <Import-Package>
                             javax.persistence;resolution:=optional,
                             org.slf4j;resolution:=optional;version="[1.7,2)",
-                            !org.jooq.*,
                             *
                         </Import-Package>
                         <_versionpolicy>[$(version;==;$(@)),$(version;+;$(@)))</_versionpolicy>


### PR DESCRIPTION
… fix the bundle to not import itself.

Signed-off-by: Claus Ibsen <claus.ibsen@gmail.com>