### PR TITLE
Sakila/PostgreSQL: Don't fail if language plpgsql already exists

### DIFF
--- a/jOOQ-examples/Sakila/postgres-sakila-db/postgres-sakila-schema.sql
+++ b/jOOQ-examples/Sakila/postgres-sakila-db/postgres-sakila-schema.sql
@@ -19,7 +19,7 @@ COMMENT ON SCHEMA public IS 'Standard public schema';
 -- Name: plpgsql; Type: PROCEDURAL LANGUAGE; Schema: -; Owner: postgres
 --
 
-CREATE PROCEDURAL LANGUAGE plpgsql;
+CREATE OR REPLACE PROCEDURAL LANGUAGE plpgsql;
 
 
 ALTER PROCEDURAL LANGUAGE plpgsql OWNER TO postgres;

--- a/jOOQ/src/main/resources/META-INF/ABOUT.txt
+++ b/jOOQ/src/main/resources/META-INF/ABOUT.txt
@@ -40,6 +40,7 @@ Authors and contributors of jOOQ or parts of jOOQ in alphabetical order:
 - Peter Ertl
 - Richard Bradley
 - Robin Stocker
+- Roland Weisleder
 - Samy Deghou
 - Sander Plas
 - Sean Wellington


### PR DESCRIPTION
When using the Sakila DB with the Docker image postgres:12.1 the initialisation fails with:
`ERROR:  language "plpgsql" already exists`

With PostgreSQL 8.4 (see [1]) and earlier it was only possible to execute:
`CREATE [ PROCEDURAL ] LANGUAGE name`

Starting with PostgreSQL 9.0 (see [2]) it is possible to execute:
`CREATE [ OR REPLACE ] [ PROCEDURAL ] LANGUAGE name`

This commit makes the SQL script incompatible with PostgreSQL 8.4 and earlier.

[1] https://www.postgresql.org/docs/8.4/sql-createlanguage.html
[2] https://www.postgresql.org/docs/9.0/sql-createlanguage.html