### PR TITLE
DDLDatabase: preserve casing of names

### DIFF
--- a/jOOQ-meta-extensions/src/main/java/org/jooq/meta/extensions/AbstractInterpretingDatabase.java
+++ b/jOOQ-meta-extensions/src/main/java/org/jooq/meta/extensions/AbstractInterpretingDatabase.java
@@ -95,7 +95,7 @@ public abstract class AbstractInterpretingDatabase extends H2Database {
                 Properties info = new Properties();
                 info.put("user", "sa");
                 info.put("password", "");
-                connection = new org.h2.Driver().connect("jdbc:h2:mem:jooq-meta-extensions-" + UUID.randomUUID(), info);
+                connection = new org.h2.Driver().connect("jdbc:h2:mem:jooq-meta-extensions-" + UUID.randomUUID() + ";DATABASE_TO_UPPER=false", info);
 
                 export();
             }

--- a/jOOQ/src/main/resources/META-INF/ABOUT.txt
+++ b/jOOQ/src/main/resources/META-INF/ABOUT.txt
@@ -7,6 +7,7 @@ Authors and contributors of jOOQ or parts of jOOQ in alphabetical order:
 - Art O Cathain
 - Artur Dryomov
 - Ben Manes
+- Benno Fünfstück
 - Brent Douglas
 - Brett Meyer
 - Christian Stein


### PR DESCRIPTION
Without the `DATABASE_TO_UPPPER` option, H2 automatically translates
unquoted lowercase identifiers such as table names to upper case. This
is especially problematic in combination with liquibase, which generates
unquoted table names by default. Reverse-engineering a schema from a
liquibase changelog using the H2 DDL emulation will thus generate the
wrong casing for table names. If you use a case-sensitive database in
production (such as MySQL), then you get runtime errors.