### PR TITLE
[#7014] Add API to bind named parameters to plain SQL QueryParts

### DIFF
--- a/jOOQ/src/main/java/org/jooq/conf/Settings.java
+++ b/jOOQ/src/main/java/org/jooq/conf/Settings.java
@@ -105,6 +105,8 @@ public class Settings
     @XmlElement(defaultValue = "INDEXED")
     @XmlSchemaType(name = "string")
     protected ParamType paramType = ParamType.INDEXED;
+    @XmlElement(defaultValue = "false")
+    protected Boolean bindByParamName = false;
     @XmlElement(defaultValue = "DEFAULT")
     @XmlSchemaType(name = "string")
     protected ParamCastMode paramCastMode = ParamCastMode.DEFAULT;
@@ -974,6 +976,14 @@ public class Settings
      */
     public void setParamCastMode(ParamCastMode value) {
         this.paramCastMode = value;
+    }
+
+    public Boolean isBindByParamName() {
+        return bindByParamName;
+    }
+
+    public void setBindByParamName(Boolean value) {
+        bindByParamName = value;
     }
 
     /**
@@ -3088,6 +3098,7 @@ public class Settings
         builder.append("backslashEscaping", backslashEscaping);
         builder.append("paramType", paramType);
         builder.append("paramCastMode", paramCastMode);
+        builder.append("bindByParamName", bindByParamName);
         builder.append("statementType", statementType);
         builder.append("inlineThreshold", inlineThreshold);
         builder.append("transactionListenerStartInvocationOrder", transactionListenerStartInvocationOrder);
@@ -3433,6 +3444,15 @@ public class Settings
             }
         } else {
             if (!paramCastMode.equals(other.paramCastMode)) {
+                return false;
+            }
+        }
+        if (bindByParamName == null) {
+            if (other.bindByParamName != null) {
+                return false;
+            }
+        } else {
+            if (!bindByParamName.equals(other.bindByParamName)) {
                 return false;
             }
         }
@@ -4066,6 +4086,7 @@ public class Settings
         result = ((prime*result)+((backslashEscaping == null)? 0 :backslashEscaping.hashCode()));
         result = ((prime*result)+((paramType == null)? 0 :paramType.hashCode()));
         result = ((prime*result)+((paramCastMode == null)? 0 :paramCastMode.hashCode()));
+        result = ((prime*result)+((bindByParamName == null)? 0 :bindByParamName.hashCode()));
         result = ((prime*result)+((statementType == null)? 0 :statementType.hashCode()));
         result = ((prime*result)+((inlineThreshold == null)? 0 :inlineThreshold.hashCode()));
         result = ((prime*result)+((transactionListenerStartInvocationOrder == null)? 0 :transactionListenerStartInvocationOrder.hashCode()));

--- a/jOOQ/src/main/resources/META-INF/ABOUT.txt
+++ b/jOOQ/src/main/resources/META-INF/ABOUT.txt
@@ -29,6 +29,7 @@ Authors and contributors of jOOQ or parts of jOOQ in alphabetical order:
 - Laurent Pireyn
 - Luc Marchaud
 - Lukas Eder
+- Matthias van de Meent
 - Matti Tahvonen
 - Michael Doberenz
 - Michael Simons


### PR DESCRIPTION
This MR implements #7014:

It adds a setting to opt-in to the new behaviour, and implements named parameter binding

The added behaviour of binding parameters is:
1.) gather all named parameters into a `Map<param_name, List<NamedParam<name=param_name>>` to deal with possibly duplicated names being bound
2.) for each named parameter that is found that is the Nth of that name, it binds the Nth entry in the list of that parameter name, or if that is out of bounds, the last entry of that parameter name.
