### PR TITLE
[jOOQ/jOOQ#11118] Attach configuration to a temporary record created in mapping of nested POJOs

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/DefaultRecordMapper.java
+++ b/jOOQ/src/main/java/org/jooq/impl/DefaultRecordMapper.java
@@ -849,6 +849,8 @@ public class DefaultRecordMapper<R extends Record, E> implements RecordMapper<R,
                         for (RecordMapper<Record, Object> mapper : entry.getValue()) {
                             RecordImplN rec = new RecordImplN(nestedMappedFields.get(prefix));
 
+                            attach(rec, record);
+
                             List<Integer> indexes = nestedIndexLookup.get(prefix);
                             for (int index = 0; index < indexes.size(); index++)
                                 rec.set(index, record.get(indexes.get(index)));
@@ -1042,6 +1044,8 @@ public class DefaultRecordMapper<R extends Record, E> implements RecordMapper<R,
                 }
                 else {
                     RecordImplN rec = new RecordImplN(nestedMappedFields[i]);
+
+                    attach(rec, record);
 
                     for (int index = 0; index < nestedIndexLookup[i].size(); index++)
                         rec.set(index, record.get(nestedIndexLookup[i].get(index)));

--- a/jOOQ/src/main/resources/META-INF/ABOUT.txt
+++ b/jOOQ/src/main/resources/META-INF/ABOUT.txt
@@ -56,6 +56,7 @@ Authors and contributors of jOOQ or parts of jOOQ in alphabetical order:
 - Timur Shaidullin
 - Thomas Darimont
 - Tsukasa Kitachi
+- Vaclav Kuzel
 - Victor Bronstein
 - Victor Z. Peng
 - Vladimir Kulev


### PR DESCRIPTION
Fixes [jOOQ/jOOQ#11118]

Attaches a configuration (if set) from an existing record into short lived nested records used for mapping nested POJOs. It does use the static [`DefaultRecordMapper.attach()`](https://github.com/jOOQ/jOOQ/blob/824e689f19b712802cbf5e44928696ce574795d5/jOOQ/src/main/java/org/jooq/impl/DefaultRecordMapper.java#L1101-L1109) method to attach configuration, which checks whether configuration should be attached, even though this may not be necessary.

**Thank you, for reviewing this PR.**