### PR TITLE
Scala deprecation fixes

### DIFF
--- a/jOOQ-scala_2.13/pom.xml
+++ b/jOOQ-scala_2.13/pom.xml
@@ -14,7 +14,7 @@
     <name>jOOQ Scala 2.13</name>
 
     <properties>
-        <scala.version>2.13.2</scala.version>
+        <scala.version>2.13.4</scala.version>
         <jooq-testdata-dir>${project.basedir}/../.data</jooq-testdata-dir>
     </properties>
 
@@ -35,6 +35,12 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <args>
+                        <arg>-deprecation</arg>
+                        <arg>-feature</arg>
+                    </args>
+                </configuration>
             </plugin>
 
             <!-- The jar plugin -->

--- a/jOOQ-scala_2.13/src/main/scala/org/jooq/scalaextensions/Conversions.scala
+++ b/jOOQ-scala_2.13/src/main/scala/org/jooq/scalaextensions/Conversions.scala
@@ -121,7 +121,7 @@ object Conversions {
         i = i + 1;
       }
 
-      sb.result
+      sb.result()
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -537,7 +537,7 @@
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>
-                    <version>4.3.0</version>
+                    <version>4.4.0</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
Bump Scala and scala-maven-plugin versions from 2.13.2 to 2.13.4 and 4.3.0 to 4.4.0 respectively.

Fixes to allow compilation with Scala 3.0. Tested to compile with Scala 2.10 through 3.0.0-M2

Added Scala compiler arguments to build to display deprecation and/or Scala feature usage warnings.