### PR TITLE
[jOOQ/jOOQ#11492] Add jbang catalog

### DIFF
--- a/codegen.java
+++ b/codegen.java
@@ -1,0 +1,11 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS org.jooq:jooq-codegen:${jooq.version:3.14.7}
+
+import static java.lang.System.*;
+
+public class codegen {
+
+    public static void main(String... args) throws Exception {
+        org.jooq.codegen.GenerationTool.main(args);
+      }
+}

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,0 +1,8 @@
+{
+  "catalogs": {},
+  "aliases": {
+    "codegen": {
+      "script-ref": "codegen.java"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds jbang catalog so you can run jooq codegen using jbang.dev

i.e. given a `library.xml` with settings for postgres the simplest way
to run using postgres driver is as follows:

`jbang --deps org.postgresql:postgresql:42.2.14 codegen@maxandersen/jooq/jbang library.xml`

Notice the `codegen@maxandersen/jooq/jbang` - that is just where this PR lives right not:
`codegen` script at `maxandersen` github user's `jooq` git repo in the `jbang` branch.

If you push this commit it gets shorten to:

`jbang --deps org.postgresql:postgresql:42.2.14 codegen@jooq/jooq library.xml`

And if we make a `jooq/jbang-catalog` repo it can be as short as:

`jbang --deps org.postgresql:postgresql:42.2.14 codegen@jooq library.xml`

In case users want to use a specific version of the codegenerator they can do that
passing in `-Djooq.version=1.2.3` as follows:

`jbang --fresh -Djooq.version=1.2.3 codegen@jooq library.xml`

Note: the `--fresh` is to just ensure it will do a fresh resolve/build in case you used a previous version that is cached.