### PR TITLE
Remove unused dependencies

### DIFF
--- a/jOOQ-examples/jOOQ-jpa-example-entities/pom.xml
+++ b/jOOQ-examples/jOOQ-jpa-example-entities/pom.xml
@@ -32,6 +32,56 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
         </dependency>
+        <exclusions>
+            <exclusion>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>antlr</groupId>
+                <artifactId>antlr</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>javax.activation</groupId>
+                <artifactId>javax.activation-api</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>com.fasterxml</groupId>
+                <artifactId>classmate</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.jboss</groupId>
+                <artifactId>jandex</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.jboss.spec.javax.transaction</groupId>
+                <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.hibernate.common</groupId>
+                <artifactId>hibernate-commons-annotations</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.javassist</groupId>
+                <artifactId>javassist</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.dom4j</groupId>
+                <artifactId>dom4j</artifactId>
+            </exclusion>
+        </exclusions>
     </dependencies>
 
     <build>


### PR DESCRIPTION
@lukaseder Hi, I am a user of project **_org.jooq:jooq-jpa-example-entities:3.15.0-SNAPSHOT_**. I found that its pom file introduced **_19_** dependencies. However, among them, **_16_** libraries (**_84%_**) have not been used by your project (the redundant dependencies are listed below). This PR helps **_org.jooq:jooq-jpa-example-entities:3.15.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.glassfish.jaxb:jaxb-runtime:jar:2.3.1:compile
org.hibernate.common:hibernate-commons-annotations:jar:5.1.0.Final:compile
com.sun.istack:istack-commons-runtime:jar:3.0.7:compile
org.jboss.logging:jboss-logging:jar:3.3.2.Final:compile
javax.xml.bind:jaxb-api:jar:2.3.1:compile
org.glassfish.jaxb:txw2:jar:2.3.1:compile
com.sun.xml.fastinfoset:FastInfoset:jar:1.2.15:compile
javax.activation:javax.activation-api:jar:1.2.0:compile
org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec:jar:1.1.1.Final:compile
org.jvnet.staxex:stax-ex:jar:1.8:compile
antlr:antlr:jar:2.7.7:compile
org.javassist:javassist:jar:3.24.0-GA:compile
org.jboss:jandex:jar:2.1.1.Final:compile
com.fasterxml:classmate:jar:1.5.1:compile
net.bytebuddy:byte-buddy:jar:1.10.2:compile
org.dom4j:dom4j:jar:2.1.1:compile
</code></pre>