### PR TITLE
ExecuteContext.exception() translates to DataAccessException with cause in case of null

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/DefaultExecuteContext.java
+++ b/jOOQ/src/main/java/org/jooq/impl/DefaultExecuteContext.java
@@ -665,7 +665,7 @@ class DefaultExecuteContext implements ExecuteContext {
 
     @Override
     public final void exception(RuntimeException e) {
-        this.exception = Tools.translate(sql(), e);
+        this.exception = Tools.translate(sql(), e, sqlException);
 
         if (Boolean.TRUE.equals(settings().isDebugInfoOnStackTrace())) {
 

--- a/jOOQ/src/main/java/org/jooq/impl/Tools.java
+++ b/jOOQ/src/main/java/org/jooq/impl/Tools.java
@@ -2873,11 +2873,11 @@ final class Tools {
     /**
      * Translate a {@link RuntimeException} to a {@link DataAccessException}
      */
-    static final RuntimeException translate(String sql, RuntimeException e) {
+    static final RuntimeException translate(String sql, RuntimeException e, SQLException cause) {
         if (e != null)
             return e;
         else
-            return new DataAccessException("SQL [" + sql + "]; Unspecified RuntimeException");
+            return new DataAccessException("SQL [" + sql + "]; Unspecified RuntimeException", cause);
     }
 
     /**


### PR DESCRIPTION
Enhances [jOOQ/jOOQ#11304]