### PR TITLE
Make information schema protected for XMLDatabase

### DIFF
--- a/jOOQ-meta/src/main/java/org/jooq/meta/xml/XMLDatabase.java
+++ b/jOOQ-meta/src/main/java/org/jooq/meta/xml/XMLDatabase.java
@@ -133,7 +133,7 @@ public class XMLDatabase extends AbstractDatabase {
 
     InformationSchema               info;
 
-    private InformationSchema info() {
+    protected InformationSchema info() {
         if (info == null) {
 
             // [#8118] Regardless of failure, prevent NPEs from subsequent calls


### PR DESCRIPTION
This PR just makes the info method of XMLDatabase can be overridden.

In my case, I need to read XML from jar resource in the classpath, I try to extend it, but I found I can't override the info method.

And I try to refactor it, make it more extendable, but I found a bug in using XSL case.
The `reader` always is `null` in line 202, and it will not load the XML file.