### PR TITLE
Fix read XML from classpath and transforming by XSL

### DIFF
--- a/jOOQ-meta/src/main/java/org/jooq/meta/xml/XMLDatabase.java
+++ b/jOOQ-meta/src/main/java/org/jooq/meta/xml/XMLDatabase.java
@@ -187,6 +187,7 @@ public class XMLDatabase extends AbstractDatabase {
                                 }
                                 else {
                                     InputStream xslIs = null;
+                                    reader = source.reader();
 
                                     try {
                                         log.info("Using XSL file", xsl);

--- a/jOOQ/src/main/java/org/jooq/FilePattern.java
+++ b/jOOQ/src/main/java/org/jooq/FilePattern.java
@@ -222,9 +222,11 @@ public final class FilePattern {
 
         try {
             if (url != null) {
-                log.info("Reading from classpath: " + pattern);
+                log.info("Reading from classpath: " + url.toString());
 
-                load0(new File(url.toURI()), loader);
+                // Create file from classpath resource url will cause the 'URI is not hierarchical' error
+                // See https://stackoverflow.com/questions/10144210/java-jar-file-use-resource-errors-uri-is-not-hierarchical
+                loader.accept(Source.of(url.openStream(), encoding));
                 loaded = true;
             }
             else {
@@ -254,10 +256,6 @@ public final class FilePattern {
             }
         }
 
-        // It is quite unlikely that a classpath URL doesn't produce a valid URI
-        catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
         catch (java.io.IOException e) {
             throw new IOException("Error while loading pattern", e);
         }


### PR DESCRIPTION
This PR fix 2 bugs of XMLDatabase.

1. Reader not be set when the XSL file be used in XML transforming. (Mentioned in the #11612)
2. FilePattern can't load the classpath resource correctly when using the XML file inside a jar.