### PR TITLE
Fix generating multi-key DAOs with Java records

### DIFF
--- a/jOOQ-codegen/src/main/java/org/jooq/codegen/JavaGenerator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/codegen/JavaGenerator.java
@@ -4265,7 +4265,11 @@ public class JavaGenerator extends AbstractGenerator {
                 else if (kotlin)
                     params.append("o.").append(getStrategy().getJavaMemberName(column, Mode.POJO));
                 else
-                    params.append("object.").append(getStrategy().getJavaGetterName(column, Mode.POJO)).append("()");
+                    params.append("object.").append(
+                        generatePojosAsJavaRecordClasses()
+                            ? getStrategy().getJavaMemberName(column, Mode.POJO)
+                            : getStrategy().getJavaGetterName(column, Mode.POJO)
+                    ).append("()");
 
                 params.append(separator);
             });

--- a/jOOQ/src/main/resources/META-INF/ABOUT.txt
+++ b/jOOQ/src/main/resources/META-INF/ABOUT.txt
@@ -36,6 +36,7 @@ Authors and contributors of jOOQ or parts of jOOQ in alphabetical order:
 - Miguel Gonzalez Sanchez
 - Mustafa Yücel
 - Nathaniel Fischer
+- Octavia Togami
 - Oliver Flege
 - Peter Ertl
 - Richard Bradley


### PR DESCRIPTION
The single-key case was correctly mapped for this, but not the multi-key case.