### PR TITLE
Setter return type must be Unit

### DIFF
--- a/jOOQ-codegen/src/main/java/org/jooq/codegen/JavaGenerator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/codegen/JavaGenerator.java
@@ -2351,7 +2351,7 @@ public class JavaGenerator extends AbstractGenerator {
                 printKotlinSetterAnnotation(out, column, Mode.RECORD);
 
                 out.println("%s%svar %s: %s?", visibility(generateInterfaces()), (generateInterfaces() ? "override " : ""), member, type);
-                out.tab(1).println("set(value): %s = set(%s, value)", setterReturnType, index);
+                out.tab(1).println("set(value) = set(%s, value)", index);
             }
             else {
                 final String nullableAnnotation = nullableOrNonnullAnnotation(out, column);


### PR DESCRIPTION
Same bug as here https://github.com/jOOQ/jOOQ/issues/12148
But for Records 

![image](https://user-images.githubusercontent.com/8628465/133829351-b4d37e6f-b901-4977-81af-80c5d5bbe6e6.png)

I guess kotlin not support return value from property setter, so just remove type hint

![image](https://user-images.githubusercontent.com/8628465/133841271-890e6fdf-1f71-4412-a49e-268c0ee4d16a.png)

Or better define `Unit` return?