### PR TITLE
Update log4j to 2.15.0 because of CVE-2021-44228

### DIFF
--- a/jOOQ-examples/jOOQ-academy/pom.xml
+++ b/jOOQ-examples/jOOQ-academy/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.11.0</version>
+            <version>2.15.0</version>
         </dependency>
 
         <!-- Testing -->

--- a/jOOQ-examples/jOOQ-javaee-example/pom.xml
+++ b/jOOQ-examples/jOOQ-javaee-example/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.11.0</version>
+            <version>2.15.0</version>
         </dependency>
 
         <!-- Testing -->

--- a/jOOQ-examples/jOOQ-javafx-example/pom.xml
+++ b/jOOQ-examples/jOOQ-javafx-example/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.11.0</version>
+            <version>2.15.0</version>
         </dependency>
 
         <!-- JavaFX -->

--- a/jOOQ-examples/jOOQ-jpa-example/pom.xml
+++ b/jOOQ-examples/jOOQ-jpa-example/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.11.0</version>
+            <version>2.15.0</version>
         </dependency>
 
         <!-- Testing -->

--- a/jOOQ-examples/jOOQ-oracle-example/pom.xml
+++ b/jOOQ-examples/jOOQ-oracle-example/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.11.0</version>
+            <version>2.15.0</version>
         </dependency>
 
         <!-- Testing -->

--- a/jOOQ-examples/jOOQ-r2dbc-example/pom.xml
+++ b/jOOQ-examples/jOOQ-r2dbc-example/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>jooq-r2dbc-example</artifactId>
     
     <properties>
-        <log4j.version>2.11.2</log4j.version>
+        <log4j.version>2.15.0</log4j.version>
     </properties>
 
     <build>

--- a/jOOQ-examples/jOOQ-spark-example/pom.xml
+++ b/jOOQ-examples/jOOQ-spark-example/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.11.0</version>
+            <version>2.15.0</version>
         </dependency>
         
         <!-- Testing -->

--- a/jOOQ-examples/jOOQ-spring-example/pom.xml
+++ b/jOOQ-examples/jOOQ-spring-example/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.11.0</version>
+            <version>2.15.0</version>
         </dependency>
 
         <!-- Spring (transitive dependencies are not listed explicitly) -->

--- a/jOOQ-examples/jOOQ-testcontainers-example/pom.xml
+++ b/jOOQ-examples/jOOQ-testcontainers-example/pom.xml
@@ -45,13 +45,13 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j18-impl</artifactId>
-            <version>2.11.2</version>
+            <version>2.15.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.11.2</version>
+            <version>2.15.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/jOOQ-examples/jOOQ-testcontainers-flyway-example/pom.xml
+++ b/jOOQ-examples/jOOQ-testcontainers-flyway-example/pom.xml
@@ -44,13 +44,13 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j18-impl</artifactId>
-            <version>2.11.2</version>
+            <version>2.15.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.11.2</version>
+            <version>2.15.0</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Update log4j2 version to 2.15.0 , because log4j2 have a RCE zero day.
more details at https://www.lunasec.io/docs/blog/log4j-zero-day/