### PR TITLE
Adds @JvmStatic annotation to expose reference instance to other JVM …

### DIFF
--- a/jOOQ-codegen/src/main/java/org/jooq/codegen/JavaGenerator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/codegen/JavaGenerator.java
@@ -3058,6 +3058,7 @@ public class JavaGenerator extends AbstractGenerator {
             out.println();
             out.println("public companion object {");
             out.javadoc("The reference instance of <code>%s</code>", udt.getQualifiedOutputName());
+            out.println("@JvmStatic");
             out.println("public val %s: %s = %s()", getStrategy().getJavaIdentifier(udt), className, className);
             out.println("}");
         }


### PR DESCRIPTION
This PR adds `@JvmStatic` annotation to expose reference instance to other JVM languages for improved interoperability for KotlinGenerator.

Other JVM languages like Java or Groovy can't access Kotlin companion object properties or functions unless the `@JvmStatic` compiler annotation is present. This will instruct the Kotlin compiler that additional static getter/setter methods should be generated.