### PR TITLE
Use more common form of 'unofficial' in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,4 +22,4 @@
 - Java:
 - Database (include vendor):
 - OS:
-- JDBC Driver (include name if inofficial driver):
+- JDBC Driver (include name if unofficial driver):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -23,4 +23,4 @@ Please describe the possible workarounds you've implemented to work around the l
 - Java:
 - Database (include vendor):
 - OS:
-- JDBC Driver (include name if inofficial driver):
+- JDBC Driver (include name if unofficial driver):

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -15,4 +15,4 @@ Before asking your question, please check out the FAQ too: https://www.jooq.org/
 - Java:
 - Database (include vendor):
 - OS:
-- JDBC Driver (include name if inofficial driver):
+- JDBC Driver (include name if unofficial driver):


### PR DESCRIPTION
I was about to say "fix typo" at first, but `inofficial` is actually [present in Merriam-Webster](https://www.merriam-webster.com/dictionary/inofficial). Regardless, it's definitely the more uncommon form and my browser (Firefox) marks `inofficial` as a typo, so... I think we are better off using the more common form here.