### PR TITLE
Automatically register PlainSQLChecker and SQLDialectChecker.

### DIFF
--- a/jOOQ-checker/src/main/java/org/jooq/checker/PlainSQLChecker.java
+++ b/jOOQ-checker/src/main/java/org/jooq/checker/PlainSQLChecker.java
@@ -39,11 +39,14 @@ package org.jooq.checker;
 
 import static com.sun.source.util.TreePath.getPath;
 
+import com.google.auto.service.AutoService;
 import org.jooq.PlainSQL;
 
 import org.checkerframework.framework.source.SourceVisitor;
 
 import com.sun.source.tree.MethodInvocationTree;
+
+import javax.annotation.processing.Processor;
 
 /**
  * A checker to disallow usage of {@link PlainSQL} API, except where allowed
@@ -51,6 +54,7 @@ import com.sun.source.tree.MethodInvocationTree;
  *
  * @author Lukas Eder
  */
+@AutoService(Processor.class)
 public class PlainSQLChecker extends AbstractChecker {
 
     @Override

--- a/jOOQ-checker/src/main/java/org/jooq/checker/SQLDialectChecker.java
+++ b/jOOQ-checker/src/main/java/org/jooq/checker/SQLDialectChecker.java
@@ -39,6 +39,7 @@ package org.jooq.checker;
 
 import static com.sun.source.util.TreePath.getPath;
 
+import com.google.auto.service.AutoService;
 import org.jooq.Require;
 import org.jooq.SQLDialect;
 import org.jooq.Support;
@@ -47,12 +48,15 @@ import org.checkerframework.framework.source.SourceVisitor;
 
 import com.sun.source.tree.MethodInvocationTree;
 
+import javax.annotation.processing.Processor;
+
 /**
  * A checker to compare {@link SQLDialect} from a use-site {@link Require}
  * annotation with a declaration-site {@link Support} annotation.
  *
  * @author Lukas Eder
  */
+@AutoService(Processor.class)
 public class SQLDialectChecker extends AbstractChecker {
 
     @Override


### PR DESCRIPTION
Added the ```AutoService``` annotation so that META-INF\services\javax.annotation.processing.Processor is generated for the checkers.

This has 2 benefits:
- It is not necessary anymore to define the ```annotationProcessor``` in the ```pom.xml```. It is automatically detected. So only the dependency needs to be added.
- More importantly it does not break other frameworks that also use annotation processing. For instance our company uses Lombok and after adding ```PlainSQLChecker``` like it is documented in https://www.jooq.org/doc/latest/manual/tools/checker-framework/#plainsqlchecker compilation broke as ```log``` from Lombok wasn't found anymore. This is understandable as using an ```annotationProcessors``` block means that it simply should use the explicitly defined and not auto detect. Somebody not knowing the details doesn't know what's going on as Lombok states to simply add the dependency and that's it (see https://projectlombok.org/setup/maven). At first it's unclear which ```annotationProcessors``` need to be added for Lombok to work again as this is not normally needed.

For reference:
- https://www.baeldung.com/java-annotation-processing-builder#5-using-the-google-auto-service-library

If this is ok, can it please also be merged to version-3.16.0-branch.

Thanks :-)