### PR TITLE
getSQL for specific dialect

### DIFF
--- a/jOOQ/src/main/java/org/jooq/AttachableQueryPart.java
+++ b/jOOQ/src/main/java/org/jooq/AttachableQueryPart.java
@@ -127,6 +127,44 @@ public interface AttachableQueryPart extends Attachable, QueryPart {
     String getSQL(ParamType paramType);
 
     /**
+     * Retrieve the SQL code rendered by this Query for the given SQL dialect.
+     * Does not override the dialect of the default configuration.
+     * <p>
+     * [#1520] Note that the query actually being executed might not contain any
+     * bind variables, in case the number of bind variables exceeds your SQL
+     * dialect's maximum number of supported bind variables. This is not
+     * reflected by this method, which will only use the {@link Settings} to
+     * decide whether to render bind values.
+     * <p>
+     * See {@link #getSQL()} for more details.
+     *
+     * @param sqlDialect Which {@link SQLDialect} should be rendered.
+     * @return The generated SQL
+     */
+    @NotNull
+    String getSQL(SQLDialect sqlDialect);
+
+    /**
+     * Retrieve the SQL code rendered by this Query for the given SQL dialect.
+     * Does not override the dialect of the default configuration.
+     * <p>
+     * [#1520] Note that the query actually being executed might not contain any
+     * bind variables, in case the number of bind variables exceeds your SQL
+     * dialect's maximum number of supported bind variables. This is not
+     * reflected by this method, which will only use <code>paramType</code>
+     * argument to decide whether to render bind values.
+     * <p>
+     * See {@link #getSQL()} for more details.
+     *
+     * @param paramType How to render parameters. This overrides values in
+     *            {@link Settings#getStatementType()}
+     * @param sqlDialect Which {@link SQLDialect} should be rendered.
+     * @return The generated SQL
+     */
+    @NotNull
+    String getSQL(ParamType paramType, SQLDialect sqlDialect);
+
+    /**
      * Retrieve the bind values that will be bound by this Query.
      * <p>
      * Unlike {@link #getParams()}, which returns also inlined parameters, this


### PR DESCRIPTION
Added getSQL overloads to make it possible to directly render for a specific dialect.

The dialect of the default (active) configuration remains untouched.

Reason for this extension:
We run our tests against a H2 database. It would be very handy to just run the test in debug and then get the SQL variant for the production databases (SQL Server / Oracle).

Alternatively the application itself has to be run (not tests) to get the wanted SQL variant. Or the steps from these new methods have to be done manually.

Thanks in advance for considering this change.