### PR TITLE
[jOOQ#13811] Add setting 'fieldsInLowerCase' for change case fields i…

### DIFF
--- a/jOOQ-codegen/src/main/java/org/jooq/codegen/JavaGenerator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/codegen/JavaGenerator.java
@@ -38,6 +38,7 @@
 package org.jooq.codegen;
 
 
+import static java.lang.Boolean.parseBoolean;
 import static java.util.Arrays.asList;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.counting;
@@ -84,6 +85,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -5989,12 +5991,19 @@ public class JavaGenerator extends AbstractGenerator {
             }
         }
 
+        Properties databaseProperties = database.getProperties();
+
+        boolean isFieldsInLowerCase =
+                databaseProperties.get("fieldsInLowerCase") != null &&
+                parseBoolean(databaseProperties.get("fieldsInLowerCase").toString());
+
+
         for (ColumnDefinition column : table.getColumns()) {
             final String columnTypeFull = getJavaType(column.getType(resolver(out)), out);
             final String columnType = out.ref(columnTypeFull);
             final String columnTypeRef = getJavaTypeReference(column.getDatabase(), column.getType(resolver(out)), out);
             final String columnId = out.ref(getStrategy().getJavaIdentifier(column), colRefSegments(column));
-            final String columnName = column.getName();
+            final String columnName = isFieldsInLowerCase ? column.getName().toLowerCase() : column.getName();
             final List<String> converter = out.ref(list(column.getType(resolver(out)).getConverter()));
             final List<String> binding = out.ref(list(column.getType(resolver(out)).getBinding()));
             final List<String> generator = new ArrayList<>();


### PR DESCRIPTION
Related problem described in https://github.com/jOOQ/jOOQ/issues/13811

I try to reverse engineering codegen plugin and class `LiquibaseDatabase`
I think that developer may set lower or upper case fields in generated tables and entities

**How enable setting?**
```
<database>
  <name>org.jooq.meta.extensions.liquibase.LiquibaseDatabase</name>
  <properties>
    ....
      <property>
          <key>fieldsInLowerCase</key>
          <value>true</value>
      </property>
  </properties>
</database>
```

In true value, we have dsl fields in generated entities in lowercase:

```
public final TableField<RoleEntity, Integer> ID = createField(DSL.name("id"), SQLDataType.INTEGER.nullable(false).identity(true), this, "");

/**
 * The column <code>ROLE.CODE</code>.
 */
public final TableField<RoleEntity, String> CODE = createField(DSL.name("code"), SQLDataType.VARCHAR(2147483647).nullable(false), this, "");
```

if parameter **fieldsInLowerCase** is empty or false, we have default settings:
```
public final TableField<RoleEntity, Integer> ID = createField(DSL.name("ID"), SQLDataType.INTEGER.nullable(false).identity(true), this, "");

/**
 * The column <code>ROLE.CODE</code>.
 */
public final TableField<RoleEntity, String> CODE = createField(DSL.name("CODE"), SQLDataType.VARCHAR(2147483647).nullable(false), this, "");
```

I try to execute 
`DSL.resultQuery("SELECT id FROM role").fetchInto(ROLE);`
and getting expected correctly result

Also, default query work correctly:
`DSL.resultQuery("SELECT * FROM role").fetchInto(ROLE);`

Thanks a lot for checking this PR