### PR TITLE
[#12230] Add Settings.includeSqlStringInException to allow disabling full sql query in DataAccessException

### DIFF
--- a/jOOQ/src/main/java/org/jooq/conf/Settings.java
+++ b/jOOQ/src/main/java/org/jooq/conf/Settings.java
@@ -276,6 +276,8 @@ public class Settings
     @XmlSchemaType(name = "string")
     protected ThrowExceptions throwExceptions = ThrowExceptions.THROW_ALL;
     @XmlElement(defaultValue = "true")
+    protected Boolean includeSqlStringInException = true;
+    @XmlElement(defaultValue = "true")
     protected Boolean fetchWarnings = true;
     @XmlElement(defaultValue = "0")
     protected Integer fetchServerOutputSize = 0;
@@ -3005,6 +3007,14 @@ public class Settings
         this.throwExceptions = value;
     }
 
+    public Boolean isIncludeSqlStringInException() {
+        return includeSqlStringInException;
+    }
+
+    public void setIncludeSqlStringInException(Boolean includeSqlStringInException) {
+        this.includeSqlStringInException = includeSqlStringInException;
+    }
+
     /**
      * Whether warnings should be fetched after each query execution.
      * 
@@ -5000,6 +5010,14 @@ public class Settings
         return this;
     }
 
+    /**
+     * Whether include full sql query in an exception or not
+     */
+    public Settings withIncludeSqlStringInException(Boolean value) {
+        setIncludeSqlStringInException(value);
+        return this;
+    }
+
     public Settings withFetchWarnings(Boolean value) {
         setFetchWarnings(value);
         return this;
@@ -5600,6 +5618,7 @@ public class Settings
         builder.append("cacheParsingConnectionLRUCacheSize", cacheParsingConnectionLRUCacheSize);
         builder.append("cachePreparedStatementInLoader", cachePreparedStatementInLoader);
         builder.append("throwExceptions", throwExceptions);
+        builder.append("includeSqlStringInException", includeSqlStringInException);
         builder.append("fetchWarnings", fetchWarnings);
         builder.append("fetchServerOutputSize", fetchServerOutputSize);
         builder.append("returnIdentityOnUpdatableRecord", returnIdentityOnUpdatableRecord);
@@ -6600,6 +6619,15 @@ public class Settings
                 return false;
             }
         }
+        if (includeSqlStringInException == null) {
+            if (other.includeSqlStringInException!= null) {
+                return false;
+            }
+        } else {
+            if (!includeSqlStringInException.equals(other.includeSqlStringInException)) {
+                return false;
+            }
+        }
         if (fetchWarnings == null) {
             if (other.fetchWarnings!= null) {
                 return false;
@@ -7258,6 +7286,7 @@ public class Settings
         result = ((prime*result)+((cacheParsingConnectionLRUCacheSize == null)? 0 :cacheParsingConnectionLRUCacheSize.hashCode()));
         result = ((prime*result)+((cachePreparedStatementInLoader == null)? 0 :cachePreparedStatementInLoader.hashCode()));
         result = ((prime*result)+((throwExceptions == null)? 0 :throwExceptions.hashCode()));
+        result = ((prime*result)+((includeSqlStringInException == null)? 0 :includeSqlStringInException.hashCode()));
         result = ((prime*result)+((fetchWarnings == null)? 0 :fetchWarnings.hashCode()));
         result = ((prime*result)+((fetchServerOutputSize == null)? 0 :fetchServerOutputSize.hashCode()));
         result = ((prime*result)+((returnIdentityOnUpdatableRecord == null)? 0 :returnIdentityOnUpdatableRecord.hashCode()));

--- a/jOOQ/src/main/java/org/jooq/impl/AbstractBindContext.java
+++ b/jOOQ/src/main/java/org/jooq/impl/AbstractBindContext.java
@@ -74,7 +74,7 @@ abstract class AbstractBindContext extends AbstractContext<BindContext> implemen
             return bindValue0(value, field);
         }
         catch (SQLException e) {
-            throw Tools.translate(null, e);
+            throw Tools.translate(null, e, true);
         }
     }
 

--- a/jOOQ/src/main/java/org/jooq/impl/AbstractQuery.java
+++ b/jOOQ/src/main/java/org/jooq/impl/AbstractQuery.java
@@ -233,7 +233,7 @@ abstract class AbstractQuery<R extends Record> extends AbstractAttachableQueryPa
                 statement = null;
             }
             catch (SQLException e) {
-                throw Tools.translate(rendered.sql, e);
+                throw Tools.translate(rendered.sql, e, configuration().settings().isIncludeSqlStringInException());
             }
         }
     }
@@ -245,7 +245,7 @@ abstract class AbstractQuery<R extends Record> extends AbstractAttachableQueryPa
                 statement.cancel();
             }
             catch (SQLException e) {
-                throw Tools.translate(rendered.sql, e);
+                throw Tools.translate(rendered.sql, e, configuration().settings().isIncludeSqlStringInException());
             }
         }
     }

--- a/jOOQ/src/main/java/org/jooq/impl/AbstractQueryPart.java
+++ b/jOOQ/src/main/java/org/jooq/impl/AbstractQueryPart.java
@@ -237,7 +237,7 @@ abstract class AbstractQueryPart implements QueryPartInternal {
      * Internal convenience method
      */
     protected final DataAccessException translate(String sql, SQLException e) {
-        return Tools.translate(sql, e);
+        return Tools.translate(sql, e, configuration().settings().isIncludeSqlStringInException());
     }
 
     private static final JooqLogger log = JooqLogger.getLogger(AbstractQueryPart.class, "serialization", 100);

--- a/jOOQ/src/main/java/org/jooq/impl/AbstractRoutine.java
+++ b/jOOQ/src/main/java/org/jooq/impl/AbstractRoutine.java
@@ -599,7 +599,7 @@ implements
         listener.executeEnd(ctx);
 
         if (e != null)
-            results.resultsOrRows().add(new ResultOrRowsImpl(Tools.translate(ctx.sql(), e)));
+            results.resultsOrRows().add(new ResultOrRowsImpl(Tools.translate(ctx.sql(), e, ctx.settings().isIncludeSqlStringInException())));
 
         return e;
     }

--- a/jOOQ/src/main/java/org/jooq/impl/DSL.java
+++ b/jOOQ/src/main/java/org/jooq/impl/DSL.java
@@ -560,7 +560,7 @@ public class DSL {
                 return new DefaultCloseableDSLContext(new DefaultCloseableConnectionProvider(connection), JDBCUtils.dialect(connection));
             }
             catch (SQLException e) {
-                throw Tools.translate("Error when initialising Connection", e);
+                throw Tools.translate("Error when initialising Connection", e, true);
             }
         }
     }
@@ -602,7 +602,7 @@ public class DSL {
                 return new DefaultCloseableDSLContext(new DefaultCloseableConnectionProvider(connection), JDBCUtils.dialect(connection));
             }
             catch (SQLException e) {
-                throw Tools.translate("Error when initialising Connection", e);
+                throw Tools.translate("Error when initialising Connection", e, true);
             }
         }
     }
@@ -643,7 +643,7 @@ public class DSL {
                 return new DefaultCloseableDSLContext(new DefaultCloseableConnectionProvider(connection), JDBCUtils.dialect(connection));
             }
             catch (SQLException e) {
-                throw Tools.translate("Error when initialising Connection", e);
+                throw Tools.translate("Error when initialising Connection", e, true);
             }
         }
     }

--- a/jOOQ/src/main/java/org/jooq/impl/DefaultExecuteContext.java
+++ b/jOOQ/src/main/java/org/jooq/impl/DefaultExecuteContext.java
@@ -656,7 +656,7 @@ class DefaultExecuteContext implements ExecuteContext {
 
     @Override
     public final void exception(RuntimeException e) {
-        this.exception = Tools.translate(sql(), e);
+        this.exception = Tools.translate(sql(), e, settings().isIncludeSqlStringInException());
 
         if (Boolean.TRUE.equals(settings().isDebugInfoOnStackTrace())) {
 
@@ -683,7 +683,7 @@ class DefaultExecuteContext implements ExecuteContext {
     @Override
     public final void sqlException(SQLException e) {
         this.sqlException = e;
-        exception(Tools.translate(sql(), e));
+        exception(Tools.translate(sql(), e, settings().isIncludeSqlStringInException()));
     }
 
     @Override

--- a/jOOQ/src/main/java/org/jooq/impl/MetaDataFieldProvider.java
+++ b/jOOQ/src/main/java/org/jooq/impl/MetaDataFieldProvider.java
@@ -160,7 +160,7 @@ final class MetaDataFieldProvider implements Serializable {
             }
         }
         catch (SQLException e) {
-            throw Tools.translate(null, e);
+            throw Tools.translate(null, e, configuration.settings().isIncludeSqlStringInException());
         }
 
         return new FieldsImpl<>(fields);

--- a/jOOQ/src/main/java/org/jooq/impl/Tools.java
+++ b/jOOQ/src/main/java/org/jooq/impl/Tools.java
@@ -3309,47 +3309,47 @@ final class Tools {
     /**
      * Translate a {@link R2dbcException} to a {@link DataAccessException}
      */
-    static final RuntimeException translate(String sql, Throwable t) {
+    static final RuntimeException translate(String sql, Throwable t, boolean includeSql) {
         if (t instanceof R2dbcException e)
-            return translate(sql, e);
+            return translate(sql, e, includeSql);
         else if (t instanceof SQLException e)
-            return translate(sql, e);
+            return translate(sql, e, includeSql);
         else if (t instanceof RuntimeException e)
-            return translate(sql, e);
+            return translate(sql, e, includeSql);
         else if (t != null)
-            return new DataAccessException("SQL [" + sql + "]; Unspecified Throwable", t);
+            return new DataAccessException((includeSql ? "SQL [" + sql + "]; " : "") + "Unspecified Throwable", t);
         else
-            return new DataAccessException("SQL [" + sql + "]; Unspecified Throwable");
+            return new DataAccessException((includeSql ? "SQL [" + sql + "]; " : "") + "Unspecified Throwable");
     }
 
     /**
      * Translate a {@link R2dbcException} to a {@link DataAccessException}
      */
-    static final DataAccessException translate(String sql, R2dbcException e) {
+    static final DataAccessException translate(String sql, R2dbcException e, boolean includeSql) {
         if (e != null)
-            return new DataAccessException("SQL [" + sql + "]; " + e.getMessage(), e);
+            return new DataAccessException((includeSql ? "SQL [" + sql + "]; " : "") + e.getMessage(), e);
         else
-            return new DataAccessException("SQL [" + sql + "]; Unspecified R2dbcException");
+            return new DataAccessException((includeSql ? "SQL [" + sql + "]; " : "") + "Unspecified R2dbcException");
     }
 
     /**
      * Translate a {@link SQLException} to a {@link DataAccessException}
      */
-    static final DataAccessException translate(String sql, SQLException e) {
+    static final DataAccessException translate(String sql, SQLException e, boolean includeSql) {
         if (e != null)
-            return new DataAccessException("SQL [" + sql + "]; " + e.getMessage(), e);
+            return new DataAccessException((includeSql ? "SQL [" + sql + "]; " : "") + e.getMessage(), e);
         else
-            return new DataAccessException("SQL [" + sql + "]; Unspecified SQLException");
+            return new DataAccessException((includeSql ? "SQL [" + sql + "]; " : "") + "Unspecified SQLException");
     }
 
     /**
      * Translate a {@link RuntimeException} to a {@link DataAccessException}
      */
-    static final RuntimeException translate(String sql, RuntimeException e) {
+    static final RuntimeException translate(String sql, RuntimeException e, boolean includeSql) {
         if (e != null)
             return e;
         else
-            return new DataAccessException("SQL [" + sql + "]; Unspecified RuntimeException");
+            return new DataAccessException((includeSql ? "SQL [" + sql + "]; " : "") + "Unspecified RuntimeException");
     }
 
     /**
@@ -4672,7 +4672,7 @@ final class Tools {
 
                 if (ctx.settings().getThrowExceptions() == THROW_NONE) {
                     ctx.sqlException(e);
-                    results.resultsOrRows().add(new ResultOrRowsImpl(Tools.translate(ctx.sql(), e)));
+                    results.resultsOrRows().add(new ResultOrRowsImpl(Tools.translate(ctx.sql(), e, ctx.settings().isIncludeSqlStringInException())));
                 }
                 else {
                     consumeExceptions(ctx.configuration(), ctx.statement(), e);

--- a/jOOQ/src/main/resources/META-INF/ABOUT.txt
+++ b/jOOQ/src/main/resources/META-INF/ABOUT.txt
@@ -36,6 +36,7 @@ Authors and contributors of jOOQ or parts of jOOQ in alphabetical order:
 - Miguel Gonzalez Sanchez
 - Mustafa Yücel
 - Nathaniel Fischer
+- Nikolay Mikheev
 - Octavia Togami
 - Oliver Flege
 - Per Lundberg


### PR DESCRIPTION
Fixes #12230 
`Settings` object seems to be available from pretty much any place where `Tools.translate` is called.
Added a simple boolean switch that defaults to `true` to preserve the current behavior.

Another option would be passing the whole `Settings` object into `translate`.