### PR TITLE
Fix incorrect grammar in XSD documentation

### DIFF
--- a/jOOQ-meta/src/main/resources/org/jooq/meta/xsd/jooq-codegen-3.18.0.xsd
+++ b/jOOQ-meta/src/main/resources/org/jooq/meta/xsd/jooq-codegen-3.18.0.xsd
@@ -1960,7 +1960,7 @@ This flag allows for turning off this default behaviour.]]></jxb:javadoc></jxb:p
 
       <element name="deprecationOnUnknownTypes" type="boolean" default="true" minOccurs="0" maxOccurs="1">
         <annotation><appinfo><jxb:property><jxb:javadoc><![CDATA[Generate deprecation annotations on references to unknown data types.
-This helps identifying columns, attributes, and parameters, which may not be usable through
+This helps to identify columns, attributes, and parameters, which may not be usable through
 jOOQ API, without adding custom data type bindings to them.]]></jxb:javadoc></jxb:property></appinfo></annotation>
       </element>
 


### PR DESCRIPTION
This wasn't me, the IDE made me do it. :wink: 

(I think "helps in identifying" would also be correct.)

![image](https://user-images.githubusercontent.com/630613/192455790-f849b2e6-551a-43e7-9c98-141ba4aee89f.png)
