### PR TITLE
[#14182] Fix typo in percentRank javadoc comment

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/DSL.java
+++ b/jOOQ/src/main/java/org/jooq/impl/DSL.java
@@ -29242,7 +29242,7 @@ public class DSL {
     }
 
     /**
-     * The <code>precent_rank() over ([analytic clause])</code> function.
+     * The <code>percent_rank() over ([analytic clause])</code> function.
      */
     @NotNull
     @Support({ CUBRID, FIREBIRD, H2, MARIADB, MYSQL, POSTGRES, SQLITE, YUGABYTEDB })


### PR DESCRIPTION
Just a one-character precent->percent typo fix similar in nature to #14182