### PR TITLE
[#14801] Fix Java String generation for non-nullable arrays

### DIFF
--- a/jOOQ-codegen/src/main/java/org/jooq/codegen/JavaGenerator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/codegen/JavaGenerator.java
@@ -5783,11 +5783,11 @@ public class JavaGenerator extends AbstractGenerator {
 
                 if (nn) {
                     if (isObjectArrayType(getJavaType(column.getType(resolver(out)), out)))
-                        out.println("result = prime * result + %s.deepHashCode(this.%s)", columnMember, Arrays.class, columnMember);
+                        out.println("result = prime * result + %s.deepHashCode(this.%s)", Arrays.class, columnMember);
                     else if (isArrayType(getJavaType(column.getType(resolver(out)), out)))
-                        out.println("result = prime * result + %s.hashCode(this.%s)", columnMember, Arrays.class, columnMember);
+                        out.println("result = prime * result + %s.hashCode(this.%s)", Arrays.class, columnMember);
                     else
-                        out.println("result = prime * result + this.%s.hashCode()", columnMember, columnMember);
+                        out.println("result = prime * result + this.%s.hashCode()", columnMember);
                 }
                 else {
                     if (isObjectArrayType(getJavaType(column.getType(resolver(out)), out)))

--- a/jOOQ/src/main/resources/META-INF/ABOUT.txt
+++ b/jOOQ/src/main/resources/META-INF/ABOUT.txt
@@ -65,6 +65,7 @@ Authors and contributors of jOOQ or parts of jOOQ in alphabetical order:
 - Vojtech Polivka
 - Wang Gaoyuan
 - Wyke Oskar
+- Xavier Oliver
 - Zoltan Tamasi
 
 See the following website for details about contributing to jOOQ:


### PR DESCRIPTION
Fixes https://github.com/jOOQ/jOOQ/issues/14801 by removing an extra parameters for String interpolation when generating Java code, which resulted in code that wouldn't compile.