### PR TITLE
[#14806] Jooq-checker JDK 17 Support

### DIFF
--- a/jOOQ-checker/src/main/java/org/jooq/checker/AbstractChecker.java
+++ b/jOOQ-checker/src/main/java/org/jooq/checker/AbstractChecker.java
@@ -43,7 +43,7 @@ import java.io.PrintWriter;
 
 import org.jooq.checker.Tools.Printer;
 
-import org.checkerframework.framework.source.Result;
+
 import org.checkerframework.framework.source.SourceChecker;
 
 /**
@@ -54,7 +54,7 @@ import org.checkerframework.framework.source.SourceChecker;
 abstract class AbstractChecker extends SourceChecker {
 
     Void error(Object node, String message) {
-        getChecker().report(Result.failure(message, node), node);
+        this.getSourceChecker().reportError(node, message);
         return null;
     }
 
@@ -69,5 +69,9 @@ abstract class AbstractChecker extends SourceChecker {
         catch (IOException ignore) {}
 
         return null;
+    }
+
+    SourceChecker getSourceChecker() {
+        return this;
     }
 }

--- a/jOOQ-checker/src/main/java/org/jooq/checker/PlainSQLChecker.java
+++ b/jOOQ-checker/src/main/java/org/jooq/checker/PlainSQLChecker.java
@@ -55,7 +55,7 @@ public class PlainSQLChecker extends AbstractChecker {
 
     @Override
     protected SourceVisitor<Void, Void> createSourceVisitor() {
-        return new SourceVisitor<Void, Void>(getChecker()) {
+        return new SourceVisitor<Void, Void>(getSourceChecker()) {
 
             @Override
             public Void visitMethodInvocation(MethodInvocationTree node, Void p) {

--- a/jOOQ-checker/src/main/java/org/jooq/checker/SQLDialectChecker.java
+++ b/jOOQ-checker/src/main/java/org/jooq/checker/SQLDialectChecker.java
@@ -57,7 +57,7 @@ public class SQLDialectChecker extends AbstractChecker {
 
     @Override
     protected SourceVisitor<Void, Void> createSourceVisitor() {
-        return new SourceVisitor<Void, Void>(getChecker()) {
+        return new SourceVisitor<Void, Void>(getSourceChecker()) {
 
             @Override
             public Void visitMethodInvocation(MethodInvocationTree node, Void p) {

--- a/jOOQ-checker/src/main/java/org/jooq/checker/Tools.java
+++ b/jOOQ-checker/src/main/java/org/jooq/checker/Tools.java
@@ -40,8 +40,8 @@ package org.jooq.checker;
 import static java.util.Arrays.asList;
 import static org.checkerframework.javacutil.TreeUtils.elementFromDeclaration;
 import static org.checkerframework.javacutil.TreeUtils.elementFromUse;
-import static org.checkerframework.javacutil.TreeUtils.enclosingClass;
-import static org.checkerframework.javacutil.TreeUtils.enclosingMethod;
+import static org.checkerframework.javacutil.TreePathUtil.enclosingClass;
+import static org.checkerframework.javacutil.TreePathUtil.enclosingMethod;
 
 import java.io.PrintWriter;
 import java.util.EnumSet;

--- a/jOOQ-xtend/pom.xml
+++ b/jOOQ-xtend/pom.xml
@@ -45,8 +45,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <encoding>UTF-8</encoding>
-
-                    <release>17</release>
+                    <!-- https://youtrack.jetbrains.com/issue/IDEA-176994 -->
+                    <!-- <release>17</release> -->
 
 
                     <!-- IntelliJ needs these https://youtrack.jetbrains.com/issue/IDEA-195472 -->

--- a/jOOQ/src/main/resources/META-INF/ABOUT.txt
+++ b/jOOQ/src/main/resources/META-INF/ABOUT.txt
@@ -36,6 +36,7 @@ Authors and contributors of jOOQ or parts of jOOQ in alphabetical order:
 - Miguel Gonzalez Sanchez
 - Mustafa Yücel
 - Nathaniel Fischer
+- Nicholas Chong W.B.
 - Octavia Togami
 - Oliver Flege
 - Per Lundberg

--- a/pom.xml
+++ b/pom.xml
@@ -537,7 +537,7 @@
             <dependency>
                 <groupId>org.checkerframework</groupId>
                 <artifactId>checker</artifactId>
-                <version>2.5.6</version>
+                <version>3.19.0</version>
             </dependency>
 
             <dependency>
@@ -613,8 +613,8 @@
                         <maxmem>512m</maxmem>
                         <meminitial>256m</meminitial>
                         <encoding>UTF-8</encoding>
-
-                        <release>17</release>
+                        <!-- https://youtrack.jetbrains.com/issue/IDEA-176994 -->
+                        <!-- <release>17</release> -->
 
 
                         <!-- IntelliJ needs these https://youtrack.jetbrains.com/issue/IDEA-195472 -->
@@ -627,6 +627,8 @@
                              But don't fail (yet) -->
                         <compilerArgs>
                             <arg>-Xlint:varargs</arg>
+                            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
                         </compilerArgs>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
# Issue 14806 : Jooq-checker JDK 17 Support

pom.xml
- Comment out `<release>17</release>` due to https://youtrack.jetbrains.com/issue/IDEA-176994
- Upgraded org.checkerframework from 2.5.6 to 3.19.0 (minimum version for JDK 17)
- Added compilerArgs as checkerframework >= 3.10.0 need access to `com.sun.tools.javac.tree` and `com.sun.tools.javac.util`

jOOQ-xtend/pom.xml
- Comment out `<release>17</release>` due to https://youtrack.jetbrains.com/issue/IDEA-176994


jOOQ-checker/src/main/java/org/jooq/checker/AbstractChecker.java
- Removed `import org.checkerframework.framework.source.Result;`
- Added getSourceChecker()
- Replaced getChecker().report() call with this.getSourceChecker().reportError()

jOOQ-checker/src/main/java/org/jooq/checker/PlainSQLChecker.java
jOOQ-checker/src/main/java/org/jooq/checker/SQLDialectChecker.java
- Replaced getChecker() call with getSourceChecker()


jOOQ-checker/src/main/java/org/jooq/checker/Tools.java
- Replaced import classpath of TreeUtils to TreePathUtil (refer to https://github.com/typetools/checker-framework/blob/master/docs/CHANGELOG.md#version-391-january-13-2021)