### PR TITLE
maven-javadoc-plugin,locale explicitly set to english

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -669,6 +669,8 @@
                         <encoding>UTF-8</encoding>
                         <show>protected</show>
                         <notree>true</notree>
+                        <!-- Explicit configuration of javadoc language to avoid defaulting to build system's configuration -->
+                        <locale>en</locale>
 
                         <!-- Avoid running into Java 8's very restrictive doclint issues -->
                         <additionalparam>-Xdoclint:none</additionalparam>


### PR DESCRIPTION
Proposal to explicitly configure the language use by `javadoc` during generation to avoid depending on the build system's configuration that can be something other than English. 

Some of the recent artifacts of `org.jooq:jooq` javadoc jar in Maven central have been built by `javadoc` using German as the `locale` language.
Refs:
- https://docs.oracle.com/en/java/javase/17/docs/specs/man/javadoc.html#options-for-javadoc 
- https://maven.apache.org/plugins/maven-javadoc-plugin/javadoc-mojo.html#locale

Example of German showing up:
![image](https://user-images.githubusercontent.com/1125783/230617319-8d81fd93-8d6c-4025-ae5d-6486a85bad9d.png)


Report for the last 30 releases of the language found in `index.html`.
Can be found as well at https://www.javadoc.io/doc/org.jooq/jooq/latest/org.jooq/module-summary.html 
```
3.14.16	<div>JavaScript is disabled on your browser.</div>
3.15.10	<p>JavaScript is disabled on your browser.</p>
3.15.11	<p>JavaScript is disabled on your browser.</p>
3.15.12	<p>JavaScript is disabled on your browser.</p>
3.16.7	<p>JavaScript is disabled on your browser.</p>
3.16.8	<p>JavaScript is disabled on your browser.</p>
3.16.9	<p>JavaScript is disabled on your browser.</p>
3.16.10	<p>JavaScript is disabled on your browser.</p>
3.16.11	<p>JavaScript is disabled on your browser.</p>
3.16.12	<p>JavaScript is disabled on your browser.</p>
3.16.13	<p>JavaScript is disabled on your browser.</p>
3.16.14	<p>JavaScript is disabled on your browser.</p>
3.16.15	<p>JavaScript is disabled on your browser.</p>
3.16.16	<p>JavaScript is disabled on your browser.</p>
3.16.17	<p>JavaScript is disabled on your browser.</p>
3.17.0	<p>JavaScript is disabled on your browser.</p>
3.17.1	<p>JavaScript is disabled on your browser.</p>
3.17.2	<p>JavaScript is disabled on your browser.</p>
3.17.3	<p>JavaScript is disabled on your browser.</p>
3.17.4	<p>JavaScript is disabled on your browser.</p>
3.17.5	<p>JavaScript is disabled on your browser.</p>
3.17.6	<p>JavaScript is disabled on your browser.</p>
3.17.7	<p>JavaScript is disabled on your browser.</p>
3.17.8	<p>JavaScript ist im Browser deaktiviert.</p>
3.17.9	<p>JavaScript is disabled on your browser.</p>
3.17.10	<p>JavaScript ist im Browser deaktiviert.</p>
3.17.11	<p>JavaScript ist im Browser deaktiviert.</p>
3.18.0	<p>JavaScript is disabled on your browser.</p>
3.18.1	<p>JavaScript ist im Browser deaktiviert.</p>
3.18.2	<p>JavaScript ist im Browser deaktiviert.</p>
```

Script used to create above report
```
#!/bin/bash

set -o pipefail
set -o errexit
set -o nounset

trap "echo exit; exit;" SIGINT SIGTERM

tags=$(curl -sL --output - "https://search.maven.org/solrsearch/select?q=g:org.jooq+AND+a:jooq&core=gav&rows=30&wt=json" | jq -r '.response.docs[] | .v' | sort -V)

for tag in $tags; do
    echo -en $tag'\t'
    curl --silent -L "https://repo1.maven.org/maven2/org/jooq/jooq/${tag}/jooq-${tag}-javadoc.jar" | jar xv /dev/stdin index.html >/dev/null && rc=$? || rc=$?
    cat index.html | grep "JavaScript i"
done
```