### PR TITLE
Maven and Maven build related updates

### DIFF
--- a/jOOQ-codegen-maven/pom.xml
+++ b/jOOQ-codegen-maven/pom.xml
@@ -13,6 +13,10 @@
     <name>jOOQ Codegen Maven</name>
     <packaging>maven-plugin</packaging>
 
+    <prerequisites>
+        <maven>3.2.5</maven>
+    </prerequisites>
+
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
@@ -52,11 +56,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <configuration>
-
-                    <!-- see http://jira.codehaus.org/browse/MNG-5346 -->
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
-                </configuration>
                 <executions>
                     <execution>
                         <id>mojo-descriptor</id>
@@ -73,15 +72,6 @@
                         </goals>
                     </execution>
                 </executions>
-                
-                <!-- Workaround for https://issues.apache.org/jira/browse/MPLUGIN-369 -->
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.plugin-tools</groupId>
-                        <artifactId>maven-plugin-tools-annotations</artifactId>
-                        <version>3.6.1</version>
-                    </dependency>
-                </dependencies>
             </plugin>
             
             <plugin>
@@ -103,26 +93,20 @@
             <groupId>org.jooq</groupId>
             <artifactId>jooq-codegen</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-
-            <!-- junit 4.8.2 sneaking in here -->
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,11 @@
     <url>http://www.jooq.org</url>
 
     <properties>
+        <!--
+        File encodings.
+        -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- These in-memory DBs are used by jOOQ-meta-extensions and a variety of integration tests -->
         <h2.version>2.1.214</h2.version>
@@ -592,17 +597,17 @@
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-api</artifactId>
-                <version>3.9.0</version>
+                <version>3.9.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-core</artifactId>
-                <version>3.9.0</version>
+                <version>3.9.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.plugin-tools</groupId>
                 <artifactId>maven-plugin-annotations</artifactId>
-                <version>3.8.1</version>
+                <version>3.8.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -613,8 +618,13 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.10.1</version>
+                    <version>3.11.0</version>
 
                     <configuration>
                         <!-- When compilers say false, they mean true ...
@@ -645,7 +655,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.1</version>
                     <inherited>true</inherited>
                     <executions>
                         <execution>
@@ -664,7 +674,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.5.0</version>
                     <inherited>true</inherited>
                     <executions>
                         <execution>
@@ -707,7 +717,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.8.2</version>
 
                     <!-- Required for Java 19 -->
                     <dependencies>
@@ -802,7 +812,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>3.1.0</version>
                     <configuration>
                         <testNGArtifactName>none:none</testNGArtifactName>
                     </configuration>
@@ -820,7 +830,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.3.0</version>
 
                     <configuration>
                         <archive>
@@ -832,6 +842,12 @@
                 </plugin>
 
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.3.1</version>
+                </plugin>
+
+                <plugin>
                     <groupId>org.jooq</groupId>
                     <artifactId>jooq-codegen-maven</artifactId>
                     <version>${project.version}</version>
@@ -840,7 +856,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>7.1.1</version>
+                    <version>8.2.1</version>
                     <configuration>
                         <failBuildOnCVSS>0</failBuildOnCVSS>
                         <skipTestScope>true</skipTestScope>
@@ -852,16 +868,31 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.8</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.1.0</version>
-                <configuration>
-                    <encoding>UTF-8</encoding>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Changes:
* fix jooq-maven-plugin, it emits warnings in 3.9.x (deps in bad scope), set prerequisite (same as ASF Maven plugins: 3.2.5, adjust if needed)
* update plugins where applicable (others may be updated as well, but did not touch non-ASF Maven plugins)
* remove obsolete or old things
* set project encoding to UTF8
* enforce minimum "modern" Maven 3.8.x for build

Ultimate goal is to get rid of Maven 3.9.x plugin validation warnings when building a project that uses jooq-maven-plugin.