### PR TITLE
Fix the set property's overrides

### DIFF
--- a/jOOQ-codegen/src/main/java/org/jooq/codegen/GenerationTool.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/codegen/GenerationTool.java
@@ -1027,8 +1027,9 @@ public class GenerationTool {
         Predicate<? super T> checkDefault
     ) {
         String p = System.getProperty(property);
+        boolean currentValueIsDefault = checkDefault.test(get.apply(configurationObject));
 
-        if (override ? p != null : checkDefault.test(get.apply(configurationObject)))
+        if ((p != null && currentValueIsDefault) || override)
             set.accept(configurationObject, convert.apply(p));
     }
 


### PR DESCRIPTION
I noticed while working on an unrelated feature proposal, and testing it with a production project, that the jooq-maven-plugin was failing with NPE because the `set()` method was overwriting the `targetDirectory` even though `override` flag was not set and no system properties were passed.

Hopefully I got the idea of method correctly.

The stack trace of the NPE: 
```
Caused by: java.lang.NullPointerException
    at java.io.File.<init> (File.java:278)
    at org.jooq.codegen.GenerationTool.run0 (GenerationTool.java:724)
    at org.jooq.codegen.GenerationTool.run (GenerationTool.java:255)
    at org.jooq.codegen.GenerationTool.generate (GenerationTool.java:247)
    at org.jooq.codegen.maven.Plugin.execute (Plugin.java:253)
```

## Reproducer:

- Go to the [jooq-testcontainers-flyway-example](https://github.com/jOOQ/jOOQ/tree/5988833d099c96a4ea08a7e4abe6e27fad8302a1/jOOQ-examples/jOOQ-testcontainers-flyway-example) locally
- Remove [the line that specifies target directory](https://github.com/jOOQ/jOOQ/blob/5988833d099c96a4ea08a7e4abe6e27fad8302a1/jOOQ-examples/jOOQ-testcontainers-flyway-example/pom.xml#LL188C44-L188C44), meaning that Jooq Maven Plugin will go with the default `target/generated-sources/jooq`
- `mvn compile`

## What happens:

- `generator.getTarget().getDirectory()` points to the default directory [at the moment before this line is executed](https://github.com/jOOQ/jOOQ/blob/51fe13a253a188bc5fd25095e30c0b11f6262309/jOOQ-codegen/src/main/java/org/jooq/codegen/GenerationTool.java#L719)
- on the [following line](https://github.com/jOOQ/jOOQ/blob/3b347a030784b6888cf5be4a24681e3014055485/jOOQ-codegen/src/main/java/org/jooq/codegen/GenerationTool.java#L1029) we get `null` because we didn't specify the target directory using system property
```
String p = System.getProperty(property);
```
- [next line](https://github.com/jOOQ/jOOQ/blob/3b347a030784b6888cf5be4a24681e3014055485/jOOQ-codegen/src/main/java/org/jooq/codegen/GenerationTool.java#L1031) finds out that the `override` isn't `true` either, which makes it then check if the current target directory equals to the default value, and it does
```
if (override ? p != null : checkDefault.test(get.apply(configurationObject)))
```
- because the directory happened to equal to the default, [we set the value in the config](https://github.com/jOOQ/jOOQ/blob/3b347a030784b6888cf5be4a24681e3014055485/jOOQ-codegen/src/main/java/org/jooq/codegen/GenerationTool.java#LL1032C63-L1032C63) to whatever comes from the system property `jooq.codegen.target.directory`, which happens to be `null`
```
set.accept(configurationObject, convert.apply(p));
```

## Fix

So if I understand correctly, the logic you were going for is:
- if `override` is active, then take whatever is in the system properties, even if it's null (allowing us to unset some values, which otherwise would be impossible)
- if `override` is not active but the system property contains some value (not null) and the current value equals to `default` then use the value from the system property instead
- if `override` is not active but the system property contains some value (not null) and the current value _is not the same as default_ then ignore the system property (not sure about this one)