### PR TITLE
add table-column's comment to pojo's field

### DIFF
--- a/jOOQ-codegen/src/main/java/org/jooq/codegen/JavaGenerator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/codegen/JavaGenerator.java
@@ -5519,11 +5519,15 @@ public class JavaGenerator extends AbstractGenerator {
             out.println();
 
             if (!generatePojosAsJavaRecordClasses())
-                for (TypedElementDefinition<?> column : getTypedElements(tableUdtOrEmbeddable))
+                for (TypedElementDefinition<?> column : getTypedElements(tableUdtOrEmbeddable)){
+                    //add column's comment to pojo's field
+                    out.javadoc("[[%s]]", list(escapeEntities(comment(column))));
                     out.println("private %s%s %s;",
-                        generateImmutablePojos() ? "final " : "",
-                        out.ref(getJavaType(column.getType(resolver(out, Mode.POJO)), out, Mode.POJO)),
-                        getStrategy().getJavaMemberName(column, Mode.POJO));
+                            generateImmutablePojos() ? "final " : "",
+                            out.ref(getJavaType(column.getType(resolver(out, Mode.POJO)), out, Mode.POJO)),
+                            getStrategy().getJavaMemberName(column, Mode.POJO));
+                }
+
         }
 
         // Constructors


### PR DESCRIPTION
now for jooq 3.18.7, pojo class generated is still missed the comment of table-column,  the pull request aims to add column's comment  to pojo's field.

for  example ,  sql script as follows: 
```h2
CREATE TABLE `user_info`
(
    `id`          bigint      NOT NULL AUTO_INCREMENT COMMENT 'user's id',
    `name`        varchar(16) NOT NULL DEFAULT '' COMMENT 'user's name',
    `phone`       varchar(20) NOT NULL DEFAULT '' COMMENT 'user's telephone',
    `email`       varchar(20) NOT NULL DEFAULT '' COMMENT 'user's email',
    PRIMARY KEY (`id`)
);
COMMENT ON TABLE `user_info` IS 'user information';
```

the pojo class generated:
```java
**
 * user's information
 */
@SuppressWarnings({ "all", "unchecked", "rawtypes" })
public class UserInfo implements Serializable {

    private static final long serialVersionUID = 1L;


    /**
     * user's id
     */
    private Long id;

    /**
     * user's name
     */
    private String name;

    /**
     * user's telephone
     */
    private String phone;

    /**
     * user's email'
     */
    private String email;
 ...
}
```  