### PR TITLE
Performance improvement: use getClass() to check if object is already a UUID

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/DefaultBinding.java
+++ b/jOOQ/src/main/java/org/jooq/impl/DefaultBinding.java
@@ -5001,8 +5001,8 @@ public class DefaultBinding<T, U> implements Binding<T, U> {
 
                     if (o == null)
                         return null;
-                    else if (o instanceof UUID u)
-                        return u;
+                    else if (o.getClass() == UUID.class)
+                        return (UUID) o;
                     else
                         return Convert.convert(o.toString(), UUID.class);
                 }


### PR DESCRIPTION
When we upgraded from 3.16.0 to newer versions we had several of our performance tests start failing. Working through the pointfix versions of jOOQ we found that is the work done as part of #8439. The instanceof check combined with pattern matching to create a new variable results in a performance degradation when dealing with a large number of UUIDs. This solution uses the same method as `convert` by using `getClass` and doing the cast in the return statement.

After implementing this change our performance problems were resolved.