### PR TITLE
Fix javadoc of ControlFlowSignal.java and slightly improve performanc…

### DIFF
--- a/jOOQ/src/main/java/org/jooq/exception/ControlFlowSignal.java
+++ b/jOOQ/src/main/java/org/jooq/exception/ControlFlowSignal.java
@@ -51,8 +51,12 @@ import org.jooq.UpdatableRecord;
  * actually executing the SQL</li>
  * </ul>
  * <p>
- * Typically, a <code>ControlFlowException</code> is thrown from within an
+ * Typically, a {@code ControlFlowSignal} is thrown from within an
  * {@link ExecuteListener}.
+ *
+ * <p>
+ * This class extends {@code RuntimeException} in order to be unchecked; it does not
+ * represent an exception, however - it represents a control flow signal.
  *
  * @author Lukas Eder
  * @see ExecuteListener
@@ -60,12 +64,16 @@ import org.jooq.UpdatableRecord;
 public class ControlFlowSignal extends RuntimeException {
 
     /**
-     * Create a new <code>ControlFlowException</code>.
+     * Create a new {@code ControlFlowSignal}.
      */
-    public ControlFlowSignal() {}
+    public ControlFlowSignal() {
+
+        // [#12582] Use more efficient instantiation without suppression or stack trace.
+        super(null, null, false, false);
+    }
 
     /**
-     * Create a new <code>ControlFlowException</code>.
+     * Create a new {@code ControlFlowSignal} with an explicit {@code message}.
      */
     public ControlFlowSignal(String message) {
 


### PR DESCRIPTION
Fix javadoc of ControlFlowSignal.java and slightly improve performance of no-args constructor.

NOTE: I think this class could be further improved! The javadoc of both constructors should be completely deleted.

However, that's an opinionated update. I think it's an objectively correct opinion that is near universally shared (pointless comments need to be deleted is not, as far as I know, opinionated!), however, there's this overriding bit of lunacy in the java world where the exceedingly stupid standard javadoc linter rules override common sense. And I don't want to force 'this commit breaks linting rules' onto the project without a short discussion on the topic.

Specifically, the javadoc 'style guide' (and various tools are designed such that they assume you follow them) __require__ javadoc on all `public`/`protected` things. I disagree with this style because certain members are so simple and so well named, there is nothing more to say: The signature and context (i.e. the parameter types and names, the method name, the name of the class it is in, and so on) __cover it all__. In fact, optimally, all methods should aspire to that lofty goal. Such a member should not be documented with the obvious.

In other words, in my humble opinion, this is bad:

```java
class User {
  /*
   * Returns the name of the user.
   * @return The name of the user.
   */
  public String getName() {
    return this.name;
  }
}
```

And this is best:

```java
class User {
  public String getName() {
    return this.name;
  }
}
```

(Of course, if there _is_ useful context to offer, for example, if this is a user's legal name, or their preferred name, or which form it has, by all means).

I don't know what the project policy is on this topic. If the policy is: Yes, rzwitserloot, you're right, then, I can supply an update / second PR that completely deletes the javadoc of the constructors. They add nothing useful; I had a quick look through and I don't think there's anything meaningful to add. I don't think it is worthwhile to explicitly document that these constructors are designed to build as fast/smallest footprint throwables as possible (that's an impl detail and not inherent in the design), and couldn't think of anything else that applies specifically to either or both constructors that isn't already better said in the javadoc of the type itself.


If the project policy is: No, we want to adhere as best we can to the usual linter rules, then a new commit is _also_ needed - because the second constructor is missing:

```
@param message Some uselessly obvious line here that provides no useful insight in any way
```

Where, presumably, you might want to update that text to be slightly less infantile :)

