### PR TITLE
[jOOQ/jOOQ#17094] Prevent connection leaks on subscription cancellation in R2DBC

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/R2DBC.java
+++ b/jOOQ/src/main/java/org/jooq/impl/R2DBC.java
@@ -192,7 +192,7 @@ final class R2DBC {
         }
 
         @Override
-        public final void cancel() {
+        public void cancel() {
             complete(() -> {});
         }
 
@@ -376,14 +376,18 @@ final class R2DBC {
 
         final AbstractNonBlockingSubscription<T> downstream;
         final AtomicReference<Connection>        connection;
+        final AtomicReference<Subscription>      subscription;
 
         ConnectionSubscriber(AbstractNonBlockingSubscription<T> downstream) {
             this.downstream = downstream;
             this.connection = new AtomicReference<>();
+            this.subscription = new AtomicReference<>();
         }
 
         @Override
         public final void onSubscribe(Subscription s) {
+            // Stores the Subscription that handles the connection establishment.
+            subscription.set(s);
             s.request(1);
         }
 
@@ -402,6 +406,13 @@ final class R2DBC {
 
         @Override
         public final void onComplete() {}
+
+        public final void cancel() {
+            subscription.updateAndGet(s -> {
+                if (s != null) { s.cancel(); }
+                return null;
+            });
+        }
     }
 
     static final class QueryExecutionSubscriber<T, Q extends Query> extends ConnectionSubscriber<T> {
@@ -632,6 +643,12 @@ final class R2DBC {
         final void request2(Subscription s) {
             if (moreRequested())
                 s.request(1);
+        }
+
+        @Override
+        public final void cancel() {
+            // Safely cancels the connection acquisition if not yet established.
+            complete(() -> delegate().cancel());
         }
 
         @Override


### PR DESCRIPTION
This PR fixes #17094 

**Description:**
When using DSLContext with R2DBC's ConnectionFactory, particularly with a ConnectionPool, connections are not always properly returned to the pool under heavy query load. This leads to connection leakage, which gradually reduces the system's performance and eventually prevents any further database queries.

**Root Cause:**
The problem arises when all connections are leased from the ConnectionPool and additional queries are queued. If a pending query is canceled before it gets a connection, the cancellation isn’t handled correctly. The request remains pending, and when it finally acquires a connection, that connection is not returned to the pool, causing a leak.

**Proposed Solution:**
_Improved Cancellation Handling:_
The ConnectionSubscriber class should manage connection acquisition during cancellation by storing the Subscription in a dedicated field. This allows the connection request to be safely canceled if it’s still pending.

_Enhanced Connection Release Logic:_
The cancel method in AbstractNonBlockingSubscription should ensure that if the connection hasn’t been established or is already closed, any pending requests are properly terminated. This will prevent resource leaks and ensure prompt release of connections.