### PR TITLE
Fix issue #17515 - do not ignore unsignedTypes=false for types with a precision specifier

### DIFF
--- a/jOOQ-meta/src/main/java/org/jooq/meta/DefaultDataTypeDefinition.java
+++ b/jOOQ-meta/src/main/java/org/jooq/meta/DefaultDataTypeDefinition.java
@@ -131,7 +131,7 @@ public class DefaultDataTypeDefinition implements DataTypeDefinition {
         this.schema = schema;
 
         // [#519] [#17135] Some types have unsigned versions
-        if (!database.supportsUnsignedTypes() && typeName.toLowerCase().endsWith("unsigned"))
+        if (!database.supportsUnsignedTypes() && P_UNSIGNED.matcher(typeName).find())
             typeName = P_UNSIGNED.matcher(typeName).replaceFirst("");
 
         // [#3420] Some databases report NULL as a data type, e.g. Oracle for (some) AQ tables


### PR DESCRIPTION
Any type with the `unsigned` specifier in their name - regardless of where it appears - should be mangled when `database.supportsUnsignedTypes()` is `false`. Specifically types with a precision specifier escaped mangling so far.

I think a cleaner approach will probably be to just try to mangle (if unsigned types are disabled) and it will just not do anything if it doesn't need to:

```
if (!database.supportsUnsignedTypes())
  typeName = P_UNSIGNED.matcher(typeName).replaceFirst("");
```

But that was too much of a change for a drive-by commit. Please let me know if you want it like that anyway.