### PR TITLE
Performance improvement in BatchSingle class

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/BatchSingle.java
+++ b/jOOQ/src/main/java/org/jooq/impl/BatchSingle.java
@@ -86,6 +86,7 @@ final class BatchSingle extends AbstractBatch implements BatchBindStep {
     final Map<String, List<Integer>> nameToIndexMapping;
     final List<Object[]>             allBindValues;
     final int                        expectedBindValues;
+    List<Object>                     defaultValues;
 
     public BatchSingle(Configuration configuration, Query query) {
         super(configuration);
@@ -127,7 +128,9 @@ final class BatchSingle extends AbstractBatch implements BatchBindStep {
     @Override
     @SafeVarargs
     public final BatchSingle bind(Map<String, Object>... namedBindValues) {
-        List<Object> defaultValues = dsl.extractBindValues(query);
+        if (defaultValues == null) {
+            defaultValues = dsl.extractBindValues(query);
+        }
 
         Object[][] bindValues = new Object[namedBindValues.length][];
         for (int i = 0; i < bindValues.length; i++) {

--- a/jOOQ/src/main/resources/META-INF/ABOUT.txt
+++ b/jOOQ/src/main/resources/META-INF/ABOUT.txt
@@ -20,6 +20,7 @@ Authors and contributors of jOOQ or parts of jOOQ in alphabetical order:
 - Fabrice Le Roy
 - Gonzalo Ortiz Jaureguizar
 - Gregory Hlavac
+- Guillaume Surrel
 - Henrik Sjöstrand
 - Ivan Dugic
 - Javier Durante


### PR DESCRIPTION
Currently the Javadoc of `BatchBindStep` interface states that calling `BatchBindStep bind(Map<String, Object>... namedBindValues)` is the same as calling `BatchBindStep bind(Map<String, Object> namedBindValues)` several times: https://github.com/jOOQ/jOOQ/blob/d0cdd0c8200e7175477727615cf15425645f90b7/jOOQ/src/main/java/org/jooq/BatchBindStep.java#L140

This is not true performance wise, I noticed a significant performance boost when using the first one. This was due to the numerous calls to `extractBindValues` when using the second one several times.