### PR TITLE
Include include field names to the to string

### DIFF
--- a/jOOQ-codegen/src/main/java/org/jooq/codegen/AbstractGenerator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/codegen/AbstractGenerator.java
@@ -100,6 +100,7 @@ abstract class AbstractGenerator implements Generator {
     boolean                            generatePojosAsKotlinDataClasses                 = true;
     boolean                            generatePojosEqualsAndHashCode                   = true;
     boolean                            generatePojosToString                            = true;
+    boolean                            generatePojosToStringWithFieldNames              = false;
     boolean                            generateImmutablePojos                           = false;
     boolean                            generateSerializablePojos                        = true;
     boolean                            generateInterfaces                               = false;
@@ -1158,6 +1159,16 @@ abstract class AbstractGenerator implements Generator {
     @Override
     public void setGeneratePojosToString(boolean generatePojosToString) {
         this.generatePojosToString = generatePojosToString;
+    }
+
+    @Override
+    public boolean generatePojosToStringWithFieldNames() {
+        return generatePojosToStringWithFieldNames;
+    }
+
+    @Override
+    public void setGeneratePojosToStringWithFieldNames(boolean generatePojosToStringWithFieldNames) {
+        this.generatePojosToStringWithFieldNames = generatePojosToStringWithFieldNames;
     }
 
     @Override

--- a/jOOQ-codegen/src/main/java/org/jooq/codegen/Generator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/codegen/Generator.java
@@ -1052,6 +1052,18 @@ public interface Generator {
      */
     void setGeneratePojosToString(boolean generatePojosToString);
 
+
+    /**
+     * Whether a <code>toString()</code> method should be generated on POJOs with field names
+     * to make use of this feature, {@link #generatePojosToString()} must be enabled
+     */
+    boolean generatePojosToStringWithFieldNames();
+
+    /**
+     * Whether a <code>toString()</code> method should be generated on POJOs with field names
+     */
+    void setGeneratePojosToStringWithFieldNames(boolean generatePojosToStringWithFieldNames);
+
     /**
      * A regular expression matching all the types in generated code that should
      * be fully qualified.

--- a/jOOQ-codegen/src/main/java/org/jooq/codegen/JavaGenerator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/codegen/JavaGenerator.java
@@ -5289,7 +5289,7 @@ public class JavaGenerator extends AbstractGenerator {
             generatePojoEqualsAndHashCode(tableUdtOrEmbeddable, out);
 
         if (generatePojosToString())
-            generatePojoToString(tableUdtOrEmbeddable, out);
+            generatePojoToString(tableUdtOrEmbeddable, out, generatePojosToStringWithFieldNames());
 
         if (generateInterfaces() && !generateImmutablePojos())
             printFromAndInto(out, tableUdtOrEmbeddable, Mode.POJO);
@@ -5869,7 +5869,7 @@ public class JavaGenerator extends AbstractGenerator {
         }
     }
 
-    protected void generatePojoToString(Definition tableOrUDT, JavaWriter out) {
+    protected void generatePojoToString(Definition tableOrUDT, JavaWriter out, boolean includeFieldNames) {
         final String className = getStrategy().getJavaClassName(tableOrUDT, Mode.POJO);
 
         out.println();
@@ -5885,6 +5885,9 @@ public class JavaGenerator extends AbstractGenerator {
                 final String columnMember = getStrategy().getJavaMemberName(column, Mode.POJO);
                 final String columnType = getJavaType(column.getType(resolver(out)), out);
                 final boolean array = isArrayType(columnType);
+                if (includeFieldNames) {
+                    out.println("sb.append(\"%s: \")", columnMember);
+                }
 
                 if (columnType.equals("scala.Array[scala.Byte]"))
                     out.println("sb%s.append(\"[binary...]\")", separator);
@@ -5912,6 +5915,9 @@ public class JavaGenerator extends AbstractGenerator {
                 final String columnMember = getStrategy().getJavaMemberName(column, Mode.POJO);
                 final String columnType = getJavaType(column.getType(resolver(out)), out);
                 final boolean array = isArrayType(columnType);
+                if (includeFieldNames) {
+                    out.println("sb.append(\"%s: \")", columnMember);
+                }
 
                 if (array && columnType.equals("kotlin.ByteArray"))
                     out.println("sb%s.append(\"[binary...]\")", separator);
@@ -5939,6 +5945,9 @@ public class JavaGenerator extends AbstractGenerator {
                 final String columnMember = getStrategy().getJavaMemberName(column, Mode.POJO);
                 final String columnType = getJavaType(column.getType(resolver(out)), out);
                 final boolean array = isArrayType(columnType);
+                if (includeFieldNames) {
+                    out.println("sb.append(\"%s: \")", columnMember);
+                }
 
                 if (array && columnType.equals("byte[]"))
                     out.println("sb%s.append(\"[binary...]\");", separator);

--- a/jOOQ/src/main/resources/META-INF/ABOUT.txt
+++ b/jOOQ/src/main/resources/META-INF/ABOUT.txt
@@ -27,6 +27,7 @@ Authors and contributors of jOOQ or parts of jOOQ in alphabetical order:
 - Joseph B Phillips
 - Joseph Pachod
 - Knut Wannheden
+- Laszlo Hadadi
 - Laurent Pireyn
 - Luc Marchaud
 - Lukas Eder


### PR DESCRIPTION
On the project we have some tables where we have 20+ fields. 
We do log the pojos and would be nice to have the field name next to the value so we wouldn't need to check the field 15th is the one what we are looking for...
I found the original PR for the toString function
https://github.com/jOOQ/jOOQ/issues/1364
where the plan was to include the field names, but somehow it was missed at the end.
I added a feature flag in the config generator which has a default value false, so this feature will not break things in case someone build some logic on the toString output.