### PR TITLE
Prevent swallowed Exceptions on source file generation for tables.

### DIFF
--- a/jOOQ-codegen/src/main/java/org/jooq/codegen/JavaGenerator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/codegen/JavaGenerator.java
@@ -1663,6 +1663,7 @@ public class JavaGenerator extends AbstractGenerator {
             }
             catch (Exception e) {
                 log.error("Error while generating table record " + table, e);
+                throw new RuntimeException("Error while generating table record " + table, e);
             }
         }
 


### PR DESCRIPTION
Exceptions during source file generation do lead to missing files (e.g. `{MyTable}Record.java` would be missing), which is a critical issue and should be propagated to the call-site. I don't think there is a use-case where we want to continue and generate a partial file-set after the generator has executed.

We encountered this swallowed Exception when we updated our postgres-driver and ran into https://github.com/jOOQ/jOOQ/issues/17873 - We upgraded to jOOQ 3.19.21 and that fixed the root-cause, but the error-handling should fail-fast, abort the operation and make the call-site aware, so that it could, for example, fail a build-pipeline.