### PR TITLE
[#18892] Specify JavaSE in maven-bundle-plugin instructions.

### DIFF
--- a/jOOQ/pom.xml
+++ b/jOOQ/pom.xml
@@ -59,6 +59,9 @@
                             com.google.gson;resolution:=optional,
                             *
                         </Import-Package>
+                        <Require-Capability>
+                            osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=17))"
+                        </Require-Capability>
                         <_versionpolicy>[$(version;==;$(@)),$(version;+;$(@)))</_versionpolicy>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
In jOOQ 3.20.0 and upwards the OSGI MANIFEST.MF contains the following invalid header:
```
Require-Capability: osgi.ee;filter:="(osgi.ee=UNKNOWN)"
```

This PR fixes this by setting the header to the one used in previous releases (3.19.x), like:

```
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
```