### PR TITLE
[#19414] Fix JSONBSet using wrong json_set instead of jsonb_set

### DIFF
--- a/jOOQ/src/main/java/org/jooq/impl/JSONBSet.java
+++ b/jOOQ/src/main/java/org/jooq/impl/JSONBSet.java
@@ -120,7 +120,7 @@ implements
 
 
             default:
-                ctx.visit(function(N_JSON_SET, JSONB, field, path, JSONEntryImpl.jsonCast(ctx, value, true)));
+                ctx.visit(function(N_JSONB_SET, JSONB, field, path, JSONEntryImpl.jsonCast(ctx, value, true)));
                 break;
         }
     }

--- a/jOOQ/src/main/resources/META-INF/ABOUT.txt
+++ b/jOOQ/src/main/resources/META-INF/ABOUT.txt
@@ -71,6 +71,7 @@ Authors and contributors of jOOQ or parts of jOOQ in alphabetical order:
 - Wyke Oskar
 - Xavier Oliver
 - Zoltan Tamasi
+- Hui Qiao
 
 See the following website for details about contributing to jOOQ:
 https://github.com/jOOQ/jOOQ/blob/main/CONTRIBUTING.md


### PR DESCRIPTION
This PR fixes a minor bug where `DSL.jsonbSet()` generates `json_set(...)` 
instead of the correct PostgreSQL function `jsonb_set(...)`.
﻿
The fix updates the `accept()` method in `JSONBSet` to use `N_JSONB_SET` 
instead of `N_JSON_SET`.
﻿
No behavioral change except correcting the PostgreSQL function name.
﻿
Issue: #19414