### PR TITLE
Fix spelling errors in comments and javadoc

### DIFF
--- a/jOOQ-meta/src/main/java/org/jooq/meta/SortedList.java
+++ b/jOOQ-meta/src/main/java/org/jooq/meta/SortedList.java
@@ -48,7 +48,7 @@ import java.util.List;
  * Since the sort behaviour is stable, {@link List#add(Object)} and other single
  * item methods can sort the list in O(N). However, large additions of M
  * elements should still be done using {@link List#addAll(Collection)} to sort
- * the list in O(N log N), instead of O(M*N), which is quadradic in the worst
+ * the list in O(N log N), instead of O(M*N), which is quadratic in the worst
  * case. Removals don't require sorting.
  */
 final class SortedList<E> extends AbstractList<E> {

--- a/jOOQ-migrations/src/main/java/org/jooq/migrations/jgit/GitCommitProvider.java
+++ b/jOOQ-migrations/src/main/java/org/jooq/migrations/jgit/GitCommitProvider.java
@@ -174,7 +174,7 @@ public final class GitCommitProvider implements CommitProvider {
 
             Commit root = commits.root();
 
-            // TODO: This algorithm is quadradic in the worst case. Can we find a better one?
+            // TODO: This algorithm is quadratic in the worst case. Can we find a better one?
             // TODO: We collect all the commits from git, when we could ignore the empty ones
             while (!revCommits.isEmpty()) {
 

--- a/jOOQ/src/main/java/org/jooq/conf/Settings.java
+++ b/jOOQ/src/main/java/org/jooq/conf/Settings.java
@@ -6399,7 +6399,7 @@ public class Settings
     }
 
     /**
-     * Whether migrations to invalid commits ({@link org.jooq.Commit#valid()}) are allowed. <p><strong>This is a potentially destructive feature, which should not be turned on in production</strong>. It is useful mostly to quickly test uncommited or inconsistent changes in development.
+     * Whether migrations to invalid commits ({@link org.jooq.Commit#valid()}) are allowed. <p><strong>This is a potentially destructive feature, which should not be turned on in production</strong>. It is useful mostly to quickly test uncommitted or inconsistent changes in development.
      * 
      * @return
      *     possible object is
@@ -6411,7 +6411,7 @@ public class Settings
     }
 
     /**
-     * Whether migrations to invalid commits ({@link org.jooq.Commit#valid()}) are allowed. <p><strong>This is a potentially destructive feature, which should not be turned on in production</strong>. It is useful mostly to quickly test uncommited or inconsistent changes in development.
+     * Whether migrations to invalid commits ({@link org.jooq.Commit#valid()}) are allowed. <p><strong>This is a potentially destructive feature, which should not be turned on in production</strong>. It is useful mostly to quickly test uncommitted or inconsistent changes in development.
      * 
      * @param value
      *     allowed object is
@@ -9913,7 +9913,7 @@ public class Settings
     }
 
     /**
-     * Whether migrations to invalid commits ({@link org.jooq.Commit#valid()}) are allowed. <p><strong>This is a potentially destructive feature, which should not be turned on in production</strong>. It is useful mostly to quickly test uncommited or inconsistent changes in development.
+     * Whether migrations to invalid commits ({@link org.jooq.Commit#valid()}) are allowed. <p><strong>This is a potentially destructive feature, which should not be turned on in production</strong>. It is useful mostly to quickly test uncommitted or inconsistent changes in development.
      * 
      */
     public Settings withMigrationAllowInvalidCommits(Boolean value) {

--- a/jOOQ/src/main/java/org/jooq/tools/StringUtils.java
+++ b/jOOQ/src/main/java/org/jooq/tools/StringUtils.java
@@ -930,7 +930,7 @@ public final class StringUtils {
             return text;
         }
 
-        // if recursing, this shouldnt be less than 0
+        // if recursing, this shouldn't be less than 0
         if (timeToLive < 0) {
             throw new IllegalStateException("TimeToLive of " + timeToLive + " is less than 0: " + text);
         }

--- a/jOOQ/src/main/java/org/jooq/tools/json/Yylex.java
+++ b/jOOQ/src/main/java/org/jooq/tools/json/Yylex.java
@@ -449,9 +449,9 @@ class Yylex {
 
 
     /**
-     * Reports an error that occured while scanning.
+     * Reports an error that occurred while scanning.
      *
-     * In a wellformed scanner (no or only correct usage of
+     * In a well-formed scanner (no or only correct usage of
      * yypushback(int) and a match-all fallback rule) this method
      * will only be called with things that "Can't Possibly Happen".
      * If this method is called, something is seriously wrong
@@ -460,7 +460,7 @@ class Yylex {
      * Usual syntax/scanner level error handling should be done
      * in error fallback rules.
      *
-     * @param   errorCode  the code of the errormessage to display
+     * @param   errorCode  the code of the error message to display
      */
     private void zzScanError(int errorCode) {
         String message;


### PR DESCRIPTION
- Fix 'occured' -> 'occurred' in Yylex.java
- Fix 'quadradic' -> 'quadratic' in GitCommitProvider.java and SortedList.java
- Fix 'uncommited' -> 'uncommitted' in Settings.java (3 instances)
- Fix 'shouldnt' -> 'shouldn't' in StringUtils.java
- Fix 'wellformed' -> 'well-formed' in Yylex.java
- Fix 'errormessage' -> 'error message' in Yylex.java