### PR TITLE
[#19379] Fix duplicate column name error in DISTINCT ON emulation

### DIFF
--- a/jOOQ/src/main/resources/META-INF/ABOUT.txt
+++ b/jOOQ/src/main/resources/META-INF/ABOUT.txt
@@ -26,6 +26,7 @@ Authors and contributors of jOOQ or parts of jOOQ in alphabetical order:
 - Javier Durante
 - Johannes Bühler
 - Joseph B Phillips
+- Junhyeong Choi
 - Joseph Pachod
 - Knut Wannheden
 - Laurent Pireyn


### PR DESCRIPTION
## Summary
Fixes #19379

I mentioned my intention to work on this issue in the comments above, and proceeded with the implementation following the existing column aliasing pattern.

When DISTINCT ON is emulated using ROW_NUMBER() window function in MariaDB/MySQL, joins with tables having identically named columns would cause "Duplicate column name" errors.

## Problem
The `distinctOnEmulation()` method created a subquery without applying column aliasing, causing duplicate column names when joining tables with identically named columns (e.g., both tables having an `id` column).

## Solution
Applied the existing column aliasing infrastructure (`Tools.aliasedFields` and `Tools.unaliasedFields`) to the `distinctOnEmulation()` method, following the same pattern used in `toSQLReferenceLimitWithWindowFunctions0()`.

This ensures:
- Columns in the derived table are aliased as v0, v1, v2, etc.
- Original column names are restored in the outer query

## Example

**Before (causes error)**
```sql
SELECT t.company_id, t.company_id, ...  -- Duplicate column name!
FROM (
  SELECT offices.company_id, coworkers.company_id, ...
  ...
) t
```

**After (works correctly)**
```sql
SELECT v0 as employment_type, v1 as id, v2 as name, 
       v3 as company_id, v4 as company_id, ...
FROM (
  SELECT coworkers.employment_type as v0, 
         coworkers.id as v1,
         coworkers.name as v2,
         offices.company_id as v3,
         coworkers.company_id as v4,  -- No duplicates!
         offices.office_name as v5,
         ROW_NUMBER() OVER (...) as rn
  FROM coworkers LEFT JOIN offices ...
) t
WHERE rn = 1
```

## Changes
* Modified `SelectQueryImpl.distinctOnEmulation()` to use `Tools.aliasedFields()` for the subquery
* Modified `SelectQueryImpl.distinctOnEmulation()` to use `Tools.unaliasedFields()` for the outer query
* Added contributor name to `ABOUT.txt`

## Testing
* [x] Code compiles successfully with mvn clean compile
* [x] Follows the same pattern as existing OFFSET/FETCH emulation infrastructure
* [x]  No compilation errors or warnings introduced